### PR TITLE
Support build against OCCT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ OBJ_COMMON = $(SRC_COMMON:.cpp=.o)
 OBJ_OCE = $(SRC_OCE:.cpp=.o)
 
 INC_ROUTER = -I3rd_party/router/include/ -I3rd_party/router -I3rd_party
-INC_OCE = -I/opt/opencascade/inc/ -I/mingw64/include/oce/ -I/usr/include/oce -I/usr/include/opencascade -I${CASROOT}/include/opencascade -I/usr/local/include/OpenCASCADE
+INC_OCE = -I/opt/opencascade/inc/ -I/mingw64/include/oce/ -I/usr/include/oce -I/usr/include/opencascade -I${CASROOT}/include/opencascade -I/usr/local/include/OpenCASCADE -I/usr/include/occt
 LDFLAGS_OCE = -L /opt/opencascade/lib/ -L${CASROOT}/lib -lTKSTEP  -lTKernel  -lTKXCAF -lTKXSBase -lTKBRep -lTKCDF -lTKXDESTEP -lTKLCAF -lTKMath -lTKMesh -lTKTopAlgo -lTKPrim -lTKBO -lTKG3d
 ifeq ($(OS),Windows_NT)
 	LDFLAGS_OCE += -lTKV3d


### PR DESCRIPTION
Hi, in Debian (and eventually Ubuntu), liboce (OpenCASCADE Community Edition, a fork which has stalled) is on its way to being replaced by the original, OCCT (OpenCASCADE Technology) or libocct. I saw that there's a package for this software in Debian by searching for reverse-dependencies since the plan is to eventually remove liboce.

This patch seems to be enough to successfully build, but I didn't do any further testing. Currently in Debian Testing we have OCCT 7.3 (2018), whereas liboce is based on OCCT 6.9 (2015), so there is a possibility of bugs coming down the pipeline, but since I'm not familiar with this software or how it uses OCCT I can't probe much further.