### PR TITLE
Fix warnings

### DIFF
--- a/3rd_party/clipper/clipper.cpp
+++ b/3rd_party/clipper/clipper.cpp
@@ -3200,7 +3200,7 @@ void Clipper::BuildResult(Paths &polys)
     int cnt = PointCount(p);
     if (cnt < 2) continue;
     pg.reserve(cnt);
-    for (int i = 0; i < cnt; ++i)
+    for (int j = 0; j < cnt; ++j)
     {
       pg.push_back(p->Pt);
       p = p->Prev;
@@ -3662,7 +3662,6 @@ void Clipper::FixupFirstLefts3(OutRec* OldOutRec, OutRec* NewOutRec)
   for (PolyOutList::size_type i = 0; i < m_PolyOuts.size(); ++i)
   {
     OutRec* outRec = m_PolyOuts[i];
-    OutRec* firstLeft = ParseFirstLeft(outRec->FirstLeft);
     if (outRec->Pts && outRec->FirstLeft == OldOutRec)
       outRec->FirstLeft = NewOutRec;
   }

--- a/3rd_party/dxflib/dl_exception.h
+++ b/3rd_party/dxflib/dl_exception.h
@@ -48,8 +48,7 @@ class DXFLIB_EXPORT DL_NullStrExc : public DL_Exception {}
  * Used for exception handling.
  */
 class DXFLIB_EXPORT DL_GroupCodeExc : public DL_Exception {
-    DL_GroupCodeExc(int gc=0) : groupCode(gc) {}
-    int groupCode;
+    DL_GroupCodeExc(int gc=0) {}
 };
 #endif
 

--- a/3rd_party/poly2tri/common/utils.h
+++ b/3rd_party/poly2tri/common/utils.h
@@ -33,7 +33,9 @@
 #define UTILS_H
 
 // Otherwise #defines like M_PI are undeclared under Visual Studio
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 
 #include <exception>
 #include <math.h>

--- a/3rd_party/poly2tri/sweep/sweep.cpp
+++ b/3rd_party/poly2tri/sweep/sweep.cpp
@@ -52,8 +52,8 @@ void Sweep::SweepPoints(SweepContext& tcx)
   for (size_t i = 1; i < tcx.point_count(); i++) {
     Point& point = *tcx.GetPoint(i);
     Node* node = &PointEvent(tcx, point);
-    for (unsigned int i = 0; i < point.edge_list.size(); i++) {
-      EdgeEvent(tcx, point.edge_list[i], node);
+    for (unsigned int j = 0; j < point.edge_list.size(); j++) {
+      EdgeEvent(tcx, point.edge_list[j], node);
     }
   }
 }

--- a/3rd_party/polypartition/polypartition.cpp
+++ b/3rd_party/polypartition/polypartition.cpp
@@ -53,10 +53,10 @@ void TPPLPoly::Clear() {
 	points = NULL;
 }
 
-void TPPLPoly::Init(long numpoints) {
+void TPPLPoly::Init(long numpoints_) {
 	Clear();
-	this->numpoints = numpoints;
-	points = new TPPLPoint[numpoints];
+	this->numpoints = numpoints_;
+	points = new TPPLPoint[numpoints_];
 }
 
 void TPPLPoly::Triangle(TPPLPoint &p1, TPPLPoint &p2, TPPLPoint &p3) {
@@ -1371,9 +1371,9 @@ bool TPPLPartition::VertexSorter::operator() (long index1, long index2) {
 	return false;
 }
 
-bool TPPLPartition::ScanLineEdge::IsConvex(const TPPLPoint& p1, const TPPLPoint& p2, const TPPLPoint& p3) const {
+bool TPPLPartition::ScanLineEdge::IsConvex(const TPPLPoint& p1_, const TPPLPoint& p2_, const TPPLPoint& p3) const {
 	tppl_float tmp;
-	tmp = (p3.y-p1.y)*(p2.x-p1.x)-(p3.x-p1.x)*(p2.y-p1.y);
+	tmp = (p3.y-p1_.y)*(p2_.x-p1_.x)-(p3.x-p1_.x)*(p2_.y-p1_.y);
 	if(tmp>0) return 1;
 	else return 0;
 }

--- a/3rd_party/polypartition/polypartition.h
+++ b/3rd_party/polypartition/polypartition.h
@@ -103,8 +103,8 @@ class TPPLPoly {
             return hole;
         }
         
-        void SetHole(bool hole) {
-            this->hole = hole;
+        void SetHole(bool hole_) {
+            this->hole = hole_;
         }
         
         TPPLPoint &GetPoint(long i) {

--- a/src/board/board_rules_check.cpp
+++ b/src/board/board_rules_check.cpp
@@ -519,9 +519,6 @@ RulesCheckResult BoardRules::check_preflight(const Board *brd)
     }
 
     for (const auto &it : brd->tracks) {
-        auto width = it.second.width;
-        Net *net = it.second.net;
-        auto layer = it.second.layer;
         auto &track = it.second;
         if (!track.net) {
             r.errors.emplace_back(RulesCheckErrorLevel::FAIL);

--- a/src/board/rule_clearance_copper.hpp
+++ b/src/board/rule_clearance_copper.hpp
@@ -10,7 +10,7 @@ public:
     RuleClearanceCopper(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     RuleMatch match_1;
     RuleMatch match_2;

--- a/src/board/rule_clearance_copper_keepout.hpp
+++ b/src/board/rule_clearance_copper_keepout.hpp
@@ -11,7 +11,7 @@ public:
     RuleClearanceCopperKeepout(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     uint64_t get_clearance(PatchType pt_copper) const;
     void set_clearance(PatchType pt_copper, uint64_t c);

--- a/src/board/rule_clearance_copper_other.hpp
+++ b/src/board/rule_clearance_copper_other.hpp
@@ -10,7 +10,7 @@ public:
     RuleClearanceCopperOther(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     uint64_t get_clearance(PatchType pt_copper, PatchType pt_non_copper) const;
     void set_clearance(PatchType pt_copper, PatchType pt_non_copper, uint64_t c);

--- a/src/board/rule_clearance_silk_exp_copper.hpp
+++ b/src/board/rule_clearance_silk_exp_copper.hpp
@@ -9,7 +9,7 @@ public:
     RuleClearanceSilkscreenExposedCopper(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     uint64_t clearance_top = 0.1_mm;
     uint64_t clearance_bottom = 0.1_mm;

--- a/src/board/rule_diffpair.hpp
+++ b/src/board/rule_diffpair.hpp
@@ -10,7 +10,7 @@ public:
     RuleDiffpair(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     UUID net_class;
     int layer = 10000;

--- a/src/board/rule_hole_size.hpp
+++ b/src/board/rule_hole_size.hpp
@@ -11,8 +11,8 @@ public:
 
     std::string get_brief(const class Block *block = nullptr) const override;
 
-    RuleMatch match;
     uint64_t diameter_min = 0.1_mm;
     uint64_t diameter_max = 10_mm;
+    RuleMatch match;
 };
 } // namespace horizon

--- a/src/board/rule_hole_size.hpp
+++ b/src/board/rule_hole_size.hpp
@@ -9,7 +9,7 @@ public:
     RuleHoleSize(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     RuleMatch match;
     uint64_t diameter_min = 0.1_mm;

--- a/src/board/rule_parameters.hpp
+++ b/src/board/rule_parameters.hpp
@@ -9,7 +9,7 @@ public:
     RuleParameters(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     uint64_t solder_mask_expansion = 0.1_mm;
     uint64_t paste_mask_contraction = 0;

--- a/src/board/rule_plane.hpp
+++ b/src/board/rule_plane.hpp
@@ -11,7 +11,7 @@ public:
     RulePlane(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     RuleMatch match;
     int layer = 10000;

--- a/src/board/rule_preflight_checks.hpp
+++ b/src/board/rule_preflight_checks.hpp
@@ -9,6 +9,6 @@ public:
     RulePreflightChecks(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 };
 } // namespace horizon

--- a/src/board/rule_track_width.hpp
+++ b/src/board/rule_track_width.hpp
@@ -21,7 +21,7 @@ public:
     RuleTrackWidth(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     RuleMatch match;
     std::map<int, Widths> widths;

--- a/src/board/rule_via.hpp
+++ b/src/board/rule_via.hpp
@@ -11,7 +11,7 @@ public:
     RuleVia(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     RuleMatch match;
     UUID padstack;

--- a/src/canvas/canvas_gl.cpp
+++ b/src/canvas/canvas_gl.cpp
@@ -327,7 +327,7 @@ void CanvasGL::cursor_move(GdkEvent *motion_event)
     };
 
     auto mi = std::min_element(targets.cbegin(), targets.cend(),
-                               [this, dfn](const auto &a, const auto &b) { return dfn(a) < dfn(b); });
+                               [dfn](const auto &a, const auto &b) { return dfn(a) < dfn(b); });
     if (mi != targets.cend()) {
         auto d = sqrt(dfn(*mi));
         if (d < 30 / scale) {

--- a/src/canvas/drag_selection.cpp
+++ b/src/canvas/drag_selection.cpp
@@ -423,11 +423,11 @@ void DragSelection::Box::update()
             }
             else if (sq == CanvasGL::SelectionQualifier::TOUCH_BOX) {
                 // possible optimisation: don't use clipper
-                ClipperLib::Path box(4);
-                box.at(0) = ClipperLib::IntPoint(xmin, ymin);
-                box.at(1) = ClipperLib::IntPoint(xmin, ymax);
-                box.at(2) = ClipperLib::IntPoint(xmax, ymax);
-                box.at(3) = ClipperLib::IntPoint(xmax, ymin);
+                ClipperLib::Path clbox(4);
+                clbox.at(0) = ClipperLib::IntPoint(xmin, ymin);
+                clbox.at(1) = ClipperLib::IntPoint(xmin, ymax);
+                clbox.at(2) = ClipperLib::IntPoint(xmax, ymax);
+                clbox.at(3) = ClipperLib::IntPoint(xmax, ymin);
 
                 ClipperLib::Path sel(4);
                 auto corners = it.get_corners();
@@ -436,7 +436,7 @@ void DragSelection::Box::update()
                 }
 
                 ClipperLib::Clipper clipper;
-                clipper.AddPath(box, ClipperLib::ptSubject, true);
+                clipper.AddPath(clbox, ClipperLib::ptSubject, true);
                 clipper.AddPath(sel, ClipperLib::ptClip, true);
 
                 ClipperLib::Paths isect;

--- a/src/canvas/marker.cpp
+++ b/src/canvas/marker.cpp
@@ -14,7 +14,6 @@ static GLuint create_vao(GLuint program, GLuint &vbo_out)
     }
     GLuint position_index = glGetAttribLocation(program, "position");
     GLuint color_index = glGetAttribLocation(program, "color");
-    GLuint flags_index = glGetAttribLocation(program, "flags");
 
     GLuint vao, buffer;
 
@@ -37,12 +36,6 @@ static GLuint create_vao(GLuint program, GLuint &vbo_out)
 
     glEnableVertexAttribArray(color_index);
     glVertexAttribPointer(color_index, 3, GL_FLOAT, GL_FALSE, sizeof(Marker), (void *)offsetof(Marker, r));
-
-    /*glEnableVertexAttribArray (flags_index);
-    glVertexAttribIPointer (flags_index, 1,  GL_UNSIGNED_BYTE,
-                                                    sizeof(Marker),
-                                                    (void*)offsetof(Marker,
-    flags));*/
 
     /* enable and set the color attribute */
     /* reset the state; we will re-enable the VAO when needed */

--- a/src/canvas/render.cpp
+++ b/src/canvas/render.cpp
@@ -381,7 +381,6 @@ void Canvas::render(const SymbolPin &pin, bool interactive)
                        c_name, 0);
         }
         else { // draw perp
-            int64_t yshift = 0;
             Placement tr;
             tr.set_angle(orientation_to_angle(pin_orientation));
             auto shift = tr.transform(Coordi(-1_mm, 0));

--- a/src/canvas3d/canvas3d.hpp
+++ b/src/canvas3d/canvas3d.hpp
@@ -45,7 +45,7 @@ public:
     Color background_top_color;
     Color background_bottom_color;
 
-    void request_push();
+    void request_push() override;
     void update2(const class Board &brd);
     void prepare();
     void update_packages();
@@ -127,7 +127,7 @@ public:
 private:
     float width;
     float height;
-    void push();
+    void push() override;
     bool needs_push = false;
     bool needs_view_all = false;
 

--- a/src/canvas3d/cover.cpp
+++ b/src/canvas3d/cover.cpp
@@ -67,7 +67,6 @@ void CoverRenderer::realize()
 
 void CoverRenderer::push()
 {
-    int layer = 0;
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     n_vertices = 0;
     for (const auto &it : ca->layers) {

--- a/src/canvas3d/wall.cpp
+++ b/src/canvas3d/wall.cpp
@@ -65,7 +65,6 @@ void WallRenderer::realize()
 
 void WallRenderer::push()
 {
-    int layer = 0;
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     n_vertices = 0;
     for (const auto &it : ca->layers) {

--- a/src/core/tool_delete.cpp
+++ b/src/core/tool_delete.cpp
@@ -319,6 +319,7 @@ ToolResponse ToolDelete::begin(const ToolArgs &args)
 
         case ObjectType::INVALID:
             break;
+        default:;
         }
     }
     for (auto it : polys_del) {

--- a/src/core/tool_helper_draw_net_setting.hpp
+++ b/src/core/tool_helper_draw_net_setting.hpp
@@ -10,7 +10,7 @@ public:
     public:
         json serialize() const override;
         void load_from_json(const json &j) override;
-        uint64_t net_label_size = 1.5;
+        uint64_t net_label_size = 1.5_mm;
     };
 
     const ToolSettings *get_settings_const() const override
@@ -20,7 +20,7 @@ public:
 
     ToolID get_tool_id_for_settings() const override
     {
-        return ToolID::DRAW_LINE;
+        return ToolID::DRAW_NET;
     }
 
 protected:

--- a/src/core/tool_move.cpp
+++ b/src/core/tool_move.cpp
@@ -73,6 +73,7 @@ void ToolMove::expand_selection()
             auto poly = core.r->get_polygon(it.uuid);
             int i = 0;
             for (const auto &itv : poly->vertices) {
+                (void)sizeof itv;
                 new_sel.emplace(poly->uuid, ObjectType::POLYGON_VERTEX, i);
                 i++;
             }

--- a/src/core/tool_paste.cpp
+++ b/src/core/tool_paste.cpp
@@ -216,7 +216,7 @@ ToolResponse ToolPaste::begin_paste(const std::string &paste_data, const Coordi 
         for (auto it = o.cbegin(); it != o.cend(); ++it) {
             auto u = UUID::random();
             LineNet line(u, it.value());
-            auto update_net_line_conn = [this, &junction_xlat, &symbol_xlat, sheet](LineNet::Connection &c) {
+            auto update_net_line_conn = [&junction_xlat, &symbol_xlat, sheet](LineNet::Connection &c) {
                 if (c.junc.uuid) {
                     c.junc = &sheet->junctions.at(junction_xlat.at(c.junc.uuid));
                 }

--- a/src/core/tool_paste.hpp
+++ b/src/core/tool_paste.hpp
@@ -20,7 +20,6 @@ private:
     void fix_layer(int &la);
     void apply_shift(Coordi &c, const Coordi &cursor_pos);
     Coordi shift;
-    bool shift_set = false;
     bool data_received = false;
     ToolResponse begin_paste(const std::string &paste_data, const Coordi &cursor_pos);
     void update_tip();

--- a/src/core/tool_rotate_arbitrary.cpp
+++ b/src/core/tool_rotate_arbitrary.cpp
@@ -36,6 +36,7 @@ void ToolRotateArbitrary::expand_selection()
             auto poly = core.r->get_polygon(it.uuid);
             int i = 0;
             for (const auto &itv : poly->vertices) {
+                (void)sizeof itv;
                 new_sel.emplace(poly->uuid, ObjectType::POLYGON_VERTEX, i);
                 i++;
             }

--- a/src/core/tool_route_track.cpp
+++ b/src/core/tool_route_track.cpp
@@ -298,10 +298,10 @@ ToolResponse ToolRouteTrack::update(const ToolArgs &args)
                     if (!core.b->get_board()->get_layers().at(a.work_layer).copper) {
                         a.work_layer = 0;
                     }
-                    if ((pad->padstack.type == Padstack::Type::TOP)) {
+                    if (pad->padstack.type == Padstack::Type::TOP) {
                         a.work_layer = 0; // top
                     }
-                    else if ((pad->padstack.type == Padstack::Type::BOTTOM)) {
+                    else if (pad->padstack.type == Padstack::Type::BOTTOM) {
                         a.work_layer = -100;
                     }
                     else if (pad->padstack.type == Padstack::Type::THROUGH) {
@@ -412,8 +412,8 @@ ToolResponse ToolRouteTrack::update(const ToolArgs &args)
                     update_temp_track();
                 }
 
-                core.b->get_board()->track_path.clear();
-                core.b->get_board()->obstacles.clear();
+                brd->track_path.clear();
+                brd->obstacles.clear();
                 core.b->commit();
                 return ToolResponse::end();
             }

--- a/src/core/tool_route_track_interactive.cpp
+++ b/src/core/tool_route_track_interactive.cpp
@@ -709,7 +709,6 @@ ToolResponse ToolRouteTrackInteractive::update(const ToolArgs &args)
             else if (args.type == ToolEventType::CLICK) {
                 if (args.button == 1) {
                     wrapper->updateEndItem(args);
-                    bool needLayerSwitch = router->IsPlacingVia();
 
                     if (router->FixRoute(wrapper->m_endSnapPoint, wrapper->m_endItem)) {
                         router->StopRouting();
@@ -721,9 +720,6 @@ ToolResponse ToolRouteTrackInteractive::update(const ToolArgs &args)
                         return ToolResponse();
                     }
                     imp->canvas_update();
-
-                    // if( needLayerSwitch )
-                    //	  switchLayerOnViaPlacement();
 
                     // Synchronize the indicated layer
                     imp->set_work_layer(PNS::PNS_HORIZON_IFACE::layer_from_router(router->GetCurrentLayer()));

--- a/src/dialogs/edit_board_hole.cpp
+++ b/src/dialogs/edit_board_hole.cpp
@@ -101,7 +101,7 @@ BoardHoleDialog::BoardHoleDialog(Gtk::Window *parent, std::set<BoardHole *> &hol
             delete editor;
         editor = Gtk::manage(new MyParameterSetEditor(&hole->parameter_set, false));
         editor->populate();
-        editor->signal_apply_all().connect([this, holes, hole](ParameterID id) {
+        editor->signal_apply_all().connect([holes, hole](ParameterID id) {
             for (auto it : holes) {
                 it->parameter_set[id] = hole->parameter_set.at(id);
             }

--- a/src/dialogs/edit_keepout.cpp
+++ b/src/dialogs/edit_keepout.cpp
@@ -21,7 +21,7 @@ EditKeepoutDialog::EditKeepoutDialog(Gtk::Window *parent, Keepout *k, Core *core
       keepout(k)
 {
     add_button("Cancel", Gtk::ResponseType::RESPONSE_CANCEL);
-    auto ok_button = add_button("OK", Gtk::ResponseType::RESPONSE_OK);
+    add_button("OK", Gtk::ResponseType::RESPONSE_OK);
     set_default_response(Gtk::ResponseType::RESPONSE_OK);
     // set_default_size(400, 300);
 

--- a/src/dialogs/edit_pad_parameter_set.cpp
+++ b/src/dialogs/edit_pad_parameter_set.cpp
@@ -83,7 +83,7 @@ PadParameterSetDialog::PadParameterSetDialog(Gtk::Window *parent, std::set<class
             delete editor;
         editor = Gtk::manage(new MyParameterSetEditor(&pad->parameter_set, false));
         editor->populate();
-        editor->signal_apply_all().connect([this, pads, pad](ParameterID id) {
+        editor->signal_apply_all().connect([pads, pad](ParameterID id) {
             for (auto it : pads) {
                 it->parameter_set[id] = pad->parameter_set.at(id);
             }

--- a/src/dialogs/schematic_properties.cpp
+++ b/src/dialogs/schematic_properties.cpp
@@ -16,7 +16,6 @@ public:
 private:
     Gtk::Grid *grid = nullptr;
     Sheet *sheet;
-    Schematic *sch;
     int top = 0;
     void append_widget(const std::string &label, Gtk::Widget *w);
 };
@@ -34,7 +33,7 @@ void SheetEditor::append_widget(const std::string &label, Gtk::Widget *w)
     top++;
 }
 
-SheetEditor::SheetEditor(Sheet *s, Schematic *c, Pool *pool) : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0), sheet(s), sch(c)
+SheetEditor::SheetEditor(Sheet *s, Schematic *c, Pool *pool) : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0), sheet(s)
 {
     grid = Gtk::manage(new Gtk::Grid);
     grid->set_column_spacing(10);

--- a/src/dialogs/select_net.cpp
+++ b/src/dialogs/select_net.cpp
@@ -22,7 +22,7 @@ void SelectNetDialog::net_selected(const UUID &uu)
 
 
 SelectNetDialog::SelectNetDialog(Gtk::Window *parent, Block *b, const std::string &ti)
-    : Gtk::Dialog(ti, *parent, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_USE_HEADER_BAR), block(b)
+    : Gtk::Dialog(ti, *parent, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_USE_HEADER_BAR)
 {
     add_button("Cancel", Gtk::ResponseType::RESPONSE_CANCEL);
     auto ok_button = add_button("OK", Gtk::ResponseType::RESPONSE_OK);

--- a/src/dialogs/select_net.hpp
+++ b/src/dialogs/select_net.hpp
@@ -16,11 +16,7 @@ public:
     UUID net;
     NetSelector *net_selector;
 
-
 private:
-    Block *block = nullptr;
-
-
     void ok_clicked();
     void net_selected(const UUID &uu);
 };

--- a/src/imp/3d_view.cpp
+++ b/src/imp/3d_view.cpp
@@ -213,7 +213,7 @@ View3DWindow::View3DWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Buil
     Gtk::Revealer *model_loading_revealer;
     x->get_widget("model_loading_revealer", model_loading_revealer);
     canvas->signal_models_loading().connect(
-            [this, model_loading_revealer](bool v) { model_loading_revealer->set_reveal_child(v); });
+            [model_loading_revealer](bool v) { model_loading_revealer->set_reveal_child(v); });
 
     Gtk::ComboBoxText *msaa_combo;
     x->get_widget("msaa_combo", msaa_combo);

--- a/src/imp/imp.cpp
+++ b/src/imp/imp.cpp
@@ -266,17 +266,14 @@ void ImpBase::run(int argc, char *argv[])
                                                  }
                                              });
 
-        connect_action(ActionID::SELECTION_TOOL_BOX, [this, selection_tool_box_button](const auto &a) {
-            selection_tool_box_button->set_active(true);
-        });
+        connect_action(ActionID::SELECTION_TOOL_BOX,
+                       [selection_tool_box_button](const auto &a) { selection_tool_box_button->set_active(true); });
 
-        connect_action(ActionID::SELECTION_TOOL_LASSO, [this, selection_tool_lasso_button](const auto &a) {
-            selection_tool_lasso_button->set_active(true);
-        });
+        connect_action(ActionID::SELECTION_TOOL_LASSO,
+                       [selection_tool_lasso_button](const auto &a) { selection_tool_lasso_button->set_active(true); });
 
-        connect_action(ActionID::SELECTION_TOOL_PAINT, [this, selection_tool_paint_button](const auto &a) {
-            selection_tool_paint_button->set_active(true);
-        });
+        connect_action(ActionID::SELECTION_TOOL_PAINT,
+                       [selection_tool_paint_button](const auto &a) { selection_tool_paint_button->set_active(true); });
 
         connect_action(ActionID::SELECTION_QUALIFIER_AUTO, [this, selection_qualifier_auto_button](const auto &a) {
             if (canvas->selection_tool == CanvasGL::SelectionTool::BOX)
@@ -295,10 +292,9 @@ void ImpBase::run(int argc, char *argv[])
                                selection_qualifier_include_origin_button->set_active(true);
                        });
 
-        connect_action(ActionID::SELECTION_QUALIFIER_TOUCH_BOX,
-                       [this, selection_qualifier_touch_box_button](const auto &a) {
-                           selection_qualifier_touch_box_button->set_active(true);
-                       });
+        connect_action(ActionID::SELECTION_QUALIFIER_TOUCH_BOX, [selection_qualifier_touch_box_button](const auto &a) {
+            selection_qualifier_touch_box_button->set_active(true);
+        });
 
 
         update_selection_label();
@@ -1402,7 +1398,7 @@ void ImpBase::set_monitor_files(const std::set<std::string> &files)
             file_monitors[filename] = mon;
         }
     }
-    map_erase_if(file_monitors, [this, files](auto &it) { return files.count(it.first) == 0; });
+    map_erase_if(file_monitors, [files](auto &it) { return files.count(it.first) == 0; });
 }
 
 void ImpBase::set_monitor_items(const std::set<std::pair<ObjectType, UUID>> &items)

--- a/src/imp/imp_board.hpp
+++ b/src/imp/imp_board.hpp
@@ -18,7 +18,7 @@ protected:
     void update_action_sensitivity() override;
     void apply_preferences() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_BOARD;
     };

--- a/src/imp/imp_frame.cpp
+++ b/src/imp/imp_frame.cpp
@@ -33,7 +33,7 @@ void ImpFrame::construct()
         header_button->set_label(name_entry->get_text());
         core_frame.set_needs_save();
     });
-    core.r->signal_save().connect([this, header_button] {
+    core.r->signal_save().connect([this] {
         auto frame = core_frame.get_frame();
         frame->name = name_entry->get_text();
     });

--- a/src/imp/imp_frame.hpp
+++ b/src/imp/imp_frame.hpp
@@ -10,7 +10,7 @@ public:
 protected:
     void construct() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_FRAME;
     };

--- a/src/imp/imp_package.cpp
+++ b/src/imp/imp_package.cpp
@@ -585,7 +585,7 @@ void ImpPackage::construct()
         auto button = Gtk::manage(new Gtk::Button("Parameters..."));
         main_window->header->pack_start(*button);
         button->show();
-        button->signal_clicked().connect([this, parameter_window] { parameter_window->present(); });
+        button->signal_clicked().connect([parameter_window] { parameter_window->present(); });
     }
     parameter_window_add_polygon_expand(parameter_window);
     {

--- a/src/imp/imp_package.hpp
+++ b/src/imp/imp_package.hpp
@@ -14,7 +14,7 @@ protected:
     void construct() override;
     void apply_preferences() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_PACKAGE;
     };

--- a/src/imp/imp_padstack.cpp
+++ b/src/imp/imp_padstack.cpp
@@ -98,7 +98,7 @@ void ImpPadstack::construct()
         auto button = Gtk::manage(new Gtk::Button("Parameters..."));
         main_window->header->pack_start(*button);
         button->show();
-        button->signal_clicked().connect([this, parameter_window] { parameter_window->present(); });
+        button->signal_clicked().connect([parameter_window] { parameter_window->present(); });
     }
 
 

--- a/src/imp/imp_padstack.hpp
+++ b/src/imp/imp_padstack.hpp
@@ -9,7 +9,7 @@ public:
 protected:
     void construct() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_PADSTACK;
     };

--- a/src/imp/imp_schematic.hpp
+++ b/src/imp/imp_schematic.hpp
@@ -11,11 +11,11 @@ public:
 
 protected:
     void construct() override;
-    bool handle_broadcast(const json &j);
-    void handle_maybe_drag();
+    bool handle_broadcast(const json &j) override;
+    void handle_maybe_drag() override;
     void update_action_sensitivity() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_SCHEMATIC;
     };

--- a/src/imp/imp_symbol.hpp
+++ b/src/imp/imp_symbol.hpp
@@ -9,7 +9,7 @@ public:
 protected:
     void construct() override;
 
-    ActionCatalogItem::Availability get_editor_type_for_action() const
+    ActionCatalogItem::Availability get_editor_type_for_action() const override
     {
         return ActionCatalogItem::AVAILABLE_IN_SYMBOL;
     };

--- a/src/imp/rules/rule_editor_clearance_silk_exp_copper.cpp
+++ b/src/imp/rules/rule_editor_clearance_silk_exp_copper.cpp
@@ -30,19 +30,19 @@ void RuleEditorClearanceSilkscreenExposedCopper::populate()
     grid->set_margin_bottom(20);
     pack_start(*grid, true, true, 0);
 
-    if (auto rule2 = dynamic_cast<RuleClearanceSilkscreenExposedCopper *>(rule)) {
+    if (auto rule1 = dynamic_cast<RuleClearanceSilkscreenExposedCopper *>(rule)) {
         auto sp_top = create_sp_dim("Top clearance");
         auto sp_bot = create_sp_dim("Bottom clearance");
         sp_top->set_range(0, 100_mm);
         sp_bot->set_range(0, 100_mm);
-        sp_top->set_value(rule2->clearance_top);
-        sp_bot->set_value(rule2->clearance_bottom);
-        sp_top->signal_value_changed().connect([this, sp_top, rule2] {
-            rule2->clearance_top = sp_top->get_value_as_int();
+        sp_top->set_value(rule1->clearance_top);
+        sp_bot->set_value(rule1->clearance_bottom);
+        sp_top->signal_value_changed().connect([this, sp_top, rule1] {
+            rule1->clearance_top = sp_top->get_value_as_int();
             s_signal_updated.emit();
         });
-        sp_bot->signal_value_changed().connect([this, sp_bot, rule2] {
-            rule2->clearance_bottom = sp_bot->get_value_as_int();
+        sp_bot->signal_value_changed().connect([this, sp_bot, rule1] {
+            rule1->clearance_bottom = sp_bot->get_value_as_int();
             s_signal_updated.emit();
         });
     }

--- a/src/imp/rules/rules_window.cpp
+++ b/src/imp/rules/rules_window.cpp
@@ -114,7 +114,7 @@ RulesWindow::RulesWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builde
             show_editor(nullptr);
         }
     });
-    lb_multi->set_sort_func([this](Gtk::ListBoxRow *a, Gtk::ListBoxRow *b) {
+    lb_multi->set_sort_func([](Gtk::ListBoxRow *a, Gtk::ListBoxRow *b) {
         auto la = dynamic_cast<RuleLabel *>(a->get_child());
         auto lb = dynamic_cast<RuleLabel *>(b->get_child());
         return la->get_order() - lb->get_order();

--- a/src/package/package_rules_check.cpp
+++ b/src/package/package_rules_check.cpp
@@ -10,7 +10,6 @@ RulesCheckResult PackageRules::check_package(const class Package *pkg)
 {
     RulesCheckResult r;
     r.level = RulesCheckErrorLevel::PASS;
-    auto rule = dynamic_cast<RulePackageChecks *>(get_rule(RuleID::PACKAGE_CHECKS));
 
     if (pkg->name.size() == 0) {
         r.errors.emplace_back(RulesCheckErrorLevel::FAIL);

--- a/src/package/rule_package_checks.hpp
+++ b/src/package/rule_package_checks.hpp
@@ -9,6 +9,6 @@ public:
     RulePackageChecks(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 };
 } // namespace horizon

--- a/src/parameter/program.cpp
+++ b/src/parameter/program.cpp
@@ -188,6 +188,9 @@ std::pair<bool, std::string> ParameterProgram::run(const ParameterSet &pset)
             auto tok = dynamic_cast<TokenInt *>(token.get());
             stack.push_back(tok->value);
         } break;
+        case Token::Type::STR:
+        case Token::Type::UUID:
+            break;
         }
     }
 

--- a/src/pool-prj-mgr/pool-mgr/pool_notebook.cpp
+++ b/src/pool-prj-mgr/pool-mgr/pool_notebook.cpp
@@ -258,7 +258,7 @@ PoolNotebook::PoolNotebook(const std::string &bp, class PoolProjectManagerAppWin
 
 
         auto preview = Gtk::manage(new SymbolPreview(pool));
-        br->signal_selected().connect([this, br, preview] {
+        br->signal_selected().connect([br, preview] {
             auto sel = br->get_selected();
             preview->load(sel);
         });
@@ -371,7 +371,7 @@ PoolNotebook::PoolNotebook(const std::string &bp, class PoolProjectManagerAppWin
         paned->add2(*canvas);
         paned->show_all();
 
-        br->signal_selected().connect([this, br, canvas] {
+        br->signal_selected().connect([br, canvas] {
             auto sel = br->get_selected();
             if (!sel) {
                 canvas->clear();
@@ -438,7 +438,7 @@ PoolNotebook::PoolNotebook(const std::string &bp, class PoolProjectManagerAppWin
         paned->add2(*canvas);
         paned->show_all();
 
-        br->signal_selected().connect([this, br, canvas] {
+        br->signal_selected().connect([br, canvas] {
             auto sel = br->get_selected();
             if (!sel) {
                 canvas->clear();
@@ -546,7 +546,7 @@ PoolNotebook::PoolNotebook(const std::string &bp, class PoolProjectManagerAppWin
         paned->add2(*canvas);
         paned->show_all();
 
-        br->signal_selected().connect([this, br, canvas] {
+        br->signal_selected().connect([br, canvas] {
             auto sel = br->get_selected();
             if (!sel) {
                 canvas->clear();

--- a/src/pool-prj-mgr/pool-mgr/pool_remote_box.cpp
+++ b/src/pool-prj-mgr/pool-mgr/pool_remote_box.cpp
@@ -686,7 +686,7 @@ void PoolRemoteBox::remote_upgrade_thread()
     }
 }
 
-void PoolRemoteBox::checkout_master(class git_repository *repo)
+void PoolRemoteBox::checkout_master(git_repository *repo)
 {
     autofree_ptr<git_object> treeish(git_object_free);
     git_revparse_single(&treeish.ptr, repo, "master");

--- a/src/pool-prj-mgr/pool-mgr/pool_remote_box.hpp
+++ b/src/pool-prj-mgr/pool-mgr/pool_remote_box.hpp
@@ -5,8 +5,7 @@
 #include "util/uuid.hpp"
 #include "common/common.hpp"
 #include "nlohmann/json.hpp"
-
-class git_repository;
+#include <git2/sys/repository.h>
 
 namespace horizon {
 using json = nlohmann::json;

--- a/src/pool-prj-mgr/pool-mgr/pool_settings_box.hpp
+++ b/src/pool-prj-mgr/pool-mgr/pool_settings_box.hpp
@@ -5,8 +5,7 @@
 #include "util/uuid.hpp"
 #include "common/common.hpp"
 #include "nlohmann/json.hpp"
-
-class git_repository;
+#include <git2/sys/repository.h>
 
 namespace horizon {
 using json = nlohmann::json;

--- a/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
+++ b/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
@@ -9,7 +9,6 @@ namespace horizon {
 
 PoolProjectManagerViewCreatePool::PoolProjectManagerViewCreatePool(const Glib::RefPtr<Gtk::Builder> &builder,
                                                                    class PoolProjectManagerAppWindow *w)
-    : win(w)
 {
     builder->get_widget("create_pool_name_entry", pool_name_entry);
     builder->get_widget("create_pool_path_chooser", pool_path_chooser);

--- a/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
+++ b/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
@@ -44,6 +44,7 @@ std::pair<bool, std::string> PoolProjectManagerViewCreatePool::create()
         {
             Glib::Dir dir(base_path);
             for (const auto &it : dir) {
+                (void)sizeof it;
                 throw std::runtime_error("base path is not empty");
             }
         }

--- a/src/pool-prj-mgr/pool-mgr/view_create_pool.hpp
+++ b/src/pool-prj-mgr/pool-mgr/view_create_pool.hpp
@@ -19,7 +19,6 @@ public:
     void update();
 
 private:
-    PoolProjectManagerAppWindow *win = nullptr;
     Gtk::Entry *pool_name_entry = nullptr;
     Gtk::FileChooserButton *pool_path_chooser = nullptr;
 

--- a/src/pool-prj-mgr/pool-prj-mgr-app_win.cpp
+++ b/src/pool-prj-mgr/pool-prj-mgr-app_win.cpp
@@ -1125,7 +1125,7 @@ void PoolProjectManagerAppWindow::cleanup_pool_cache()
     }
     std::set<std::string> models_cached;
     find_files_recursive(Glib::build_filename(project->pool_cache_directory, "3d_models"),
-                         [this, &models_cached](const std::string &model_filename) {
+                         [&models_cached](const std::string &model_filename) {
                              models_cached.emplace(Glib::build_filename("3d_models", model_filename));
                          });
 

--- a/src/pool-prj-mgr/pool-prj-mgr-app_win_download.cpp
+++ b/src/pool-prj-mgr/pool-prj-mgr-app_win_download.cpp
@@ -37,6 +37,7 @@ void PoolProjectManagerAppWindow::download_thread(std::string gh_username, std::
         {
             Glib::Dir dd(dest_dir);
             for (const auto &it : dd) {
+                (void)sizeof it;
                 throw std::runtime_error("destination dir is not empty");
             }
         }

--- a/src/pool-prj-mgr/preferences_window_keys.cpp
+++ b/src/pool-prj-mgr/preferences_window_keys.cpp
@@ -14,8 +14,6 @@ public:
                                 KeySequencesPreferencesEditor *parent);
 
 private:
-    Preferences *preferences;
-    KeySequencesPreferences *keyseq_preferences;
     std::vector<KeySequence2> *keys;
     KeySequencesPreferencesEditor *parent;
 
@@ -181,7 +179,7 @@ CaptureDialog::CaptureDialog(Gtk::Window *parent)
         return true;
     });
 
-    capture_box->signal_key_press_event().connect([this, capture_box](GdkEventKey *ev) {
+    capture_box->signal_key_press_event().connect([this](GdkEventKey *ev) {
         if (!ev->is_modifier) {
             auto display = get_display()->gobj();
             auto hw_keycode = ev->hardware_keycode;
@@ -248,7 +246,7 @@ public:
 ActionEditor::ActionEditor(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder> &x, Preferences *prefs,
                            KeySequencesPreferences *keyseq_prefs, std::vector<KeySequence2> *k,
                            const std::string &title, KeySequencesPreferencesEditor *p)
-    : Gtk::Box(cobject), preferences(prefs), keyseq_preferences(keyseq_prefs), keys(k), parent(p)
+    : Gtk::Box(cobject), keys(k), parent(p)
 {
     Gtk::Label *la;
     x->get_widget("action_label", la);

--- a/src/pool/package.hpp
+++ b/src/pool/package.hpp
@@ -73,7 +73,7 @@ public:
     void update_warnings();
     int get_max_pad_name() const;
 
-    UUID get_uuid() const;
+    UUID get_uuid() const override;
 
     Package(const Package &pkg);
     void operator=(Package const &pkg);

--- a/src/property_panels/property_editor.hpp
+++ b/src/property_panels/property_editor.hpp
@@ -69,7 +69,7 @@ public:
     PropertyValue &get_value() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::Switch *sw = nullptr;
@@ -84,7 +84,7 @@ public:
     PropertyValue &get_value() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::Entry *en = nullptr;
@@ -105,7 +105,7 @@ public:
     void set_range(int64_t min, int64_t max);
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     class SpinButtonDim *sp = nullptr;
@@ -121,7 +121,7 @@ public:
     PropertyValue &get_value() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::ComboBoxText *combo = nullptr;
@@ -137,7 +137,7 @@ public:
     PropertyValue &get_value() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::Label *la = nullptr;
@@ -156,7 +156,7 @@ public:
     };
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::ComboBoxText *combo = nullptr;
@@ -178,7 +178,7 @@ public:
     bool copper_only = false;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::ComboBoxText *combo = nullptr;
@@ -195,7 +195,7 @@ public:
     PropertyValue &get_value() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::SpinButton *sp = nullptr;
@@ -214,7 +214,7 @@ public:
     void construct() override;
 
 protected:
-    virtual Gtk::Widget *create_editor();
+    Gtk::Widget *create_editor() override;
 
 private:
     Gtk::TextView *en = nullptr;

--- a/src/router/pns_horizon_iface.cpp
+++ b/src/router/pns_horizon_iface.cpp
@@ -553,7 +553,7 @@ std::unique_ptr<PNS::SOLID> PNS_HORIZON_IFACE::syncPadstack(const horizon::Padst
     ClipperLib::Clipper clipper;
 
     if (padstack->type != horizon::Padstack::Type::MECHANICAL) { // normal pad
-        auto add_polygon = [&clipper, &tr, padstack](const auto &poly) {
+        auto add_polygon = [&clipper, &tr](const auto &poly) {
             ClipperLib::Path path;
             if (poly.vertices.size() == 0) {
                 throw std::runtime_error("polygon without vertices in padstack at"

--- a/src/router/pns_horizon_iface.cpp
+++ b/src/router/pns_horizon_iface.cpp
@@ -77,17 +77,14 @@ public:
 
 private:
     PNS::ROUTER *m_router;
-    const horizon::Board *m_board;
     horizon::BoardRules *m_rules;
     PNS_HORIZON_IFACE *m_iface = nullptr;
     std::vector<horizon::RuleClearanceCopperKeepout *> m_rules_keepout;
-
-    bool m_useDpGap = false;
 };
 
 PNS_HORIZON_RULE_RESOLVER::PNS_HORIZON_RULE_RESOLVER(const horizon::Board *aBoard, horizon::BoardRules *rules,
                                                      PNS::ROUTER *aRouter)
-    : m_router(aRouter), m_board(aBoard), m_rules(rules)
+    : m_router(aRouter), m_rules(rules)
 {
     PNS::NODE *world = m_router->GetWorld();
 
@@ -113,6 +110,7 @@ static horizon::PatchType patch_type_from_kind(PNS::ITEM::PnsKind kind)
         return horizon::PatchType::TRACK;
     case PNS::ITEM::SEGMENT_T:
         return horizon::PatchType::TRACK;
+    default:;
     }
     assert(false);
     return horizon::PatchType::OTHER;

--- a/src/router/pns_horizon_iface.hpp
+++ b/src/router/pns_horizon_iface.hpp
@@ -121,7 +121,6 @@ private:
     class horizon::CanvasGL *canvas = nullptr;
     class horizon::BoardRules *rules = nullptr;
     class horizon::ViaPadstackProvider *vpp = nullptr;
-    PNS::NODE *m_world;
     PNS::ROUTER *m_router;
 
     std::unique_ptr<PNS::SOLID> syncPad(const horizon::BoardPackage *pkg, const horizon::Pad *pad);

--- a/src/schematic/rule_single_pin_net.hpp
+++ b/src/schematic/rule_single_pin_net.hpp
@@ -8,7 +8,7 @@ public:
     RuleSinglePinNet(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const;
+    std::string get_brief(const class Block *block = nullptr) const override;
 
     bool include_unnamed = true;
 };

--- a/src/widgets/pool_browser_entity.cpp
+++ b/src/widgets/pool_browser_entity.cpp
@@ -61,6 +61,7 @@ void PoolBrowserEntity::search()
               "entities.uuid WHERE entities.name LIKE ? ";
         qs << "AND (";
         for (const auto &it : tags) {
+            (void)sizeof it;
             qs << "tags.tag LIKE ? OR ";
         }
         qs << "0) GROUP by entities.uuid HAVING count(*) >= $ntags" + sort_controller->get_order_by();

--- a/src/widgets/pool_browser_package.cpp
+++ b/src/widgets/pool_browser_package.cpp
@@ -78,6 +78,7 @@ void PoolBrowserPackage::search()
               "AND packages.manufacturer LIKE ? ";
         qs << "AND (";
         for (const auto &it : tags) {
+            (void)sizeof it;
             qs << "tags.tag LIKE ? OR ";
         }
         qs << "0) GROUP by packages.uuid HAVING count(*) >= $ntags";

--- a/src/widgets/pool_browser_part.cpp
+++ b/src/widgets/pool_browser_part.cpp
@@ -99,6 +99,7 @@ void PoolBrowserPart::search()
                  "LIKE ? AND (parts.entity=? or ?) ";
         query << "AND parts.uuid IN (SELECT uuid FROM tags WHERE (";
         for (const auto &it : tags) {
+            (void)sizeof it;
             query << "tags.tag LIKE ? OR ";
         }
         query << "0) GROUP by tags.uuid HAVING count(*) >= $ntags) ";


### PR DESCRIPTION
Removes warnings as reported by Clang 6.0.0.

Commits are ordered by type of action, and with 3rd party in separate commits.

```
$ c++ -v
FreeBSD clang version 6.0.0 (tags/RELEASE_600/final 326565) (based on LLVM 6.0.0)
```

The directory `3rd_party/dxflib/` is not fully covered by this patch series. It still has some `-Wshadow` warnings.