### PR TITLE
Fix icon on wayland

### DIFF
--- a/src/imp/imp.cpp
+++ b/src/imp/imp.cpp
@@ -667,6 +667,8 @@ void ImpBase::run(int argc, char *argv[])
 
     Gtk::Window::set_default_icon_name("horizon-eda");
 
+    Glib::set_prgname("horizon-eda"); // Fixes icons on wayland
+
     app->signal_startup().connect([this, app] {
         app->add_window(*main_window);
         app->add_action("quit", [this] { main_window->close(); });


### PR DESCRIPTION
On wayland the program name needs to be set or it splits the schematic into separate taskbar icons.

Before:
![Screenshot_20190514_103638](https://user-images.githubusercontent.com/380158/57708214-f27b7700-7636-11e9-9d71-38c669788dd1.png)

After:
![Screenshot_20190514_110001](https://user-images.githubusercontent.com/380158/57708555-89483380-7637-11e9-976b-9fdc775dfe2d.png)

