### PR TITLE
Makefile: add support for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,7 +543,12 @@ ifeq ($(OS),Windows_NT)
     DEFINES += -DWIN32_UUID
     LDFLAGS_GUI = -Wl,-subsystem,windows
 else
-    LDFLAGS += -fuse-ld=gold
+    UNAME := $(shell uname)
+    ifeq ($(UNAME), Darwin)
+        # do nothing on mac os
+    else
+        LDFLAGS += -fuse-ld=gold
+    endif
 endif
 
 SRC_SHARED = $(SRC_COMMON) \


### PR DESCRIPTION
Splitted out of PR \#264.

Part of \#271.