### PR TITLE
Write build output to separate dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: make -j2
       - run:
           name: Build python module
-          command: make -j2 horizon.so
+          command: make -j2 build/horizon.so
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -608,7 +608,7 @@ OBJ_SHARED      += $(SRC_SHARED_GEN:.cpp=.oshared)
 OBJ_IMP          = $(addprefix $(OBJDIR)/,$(SRC_IMP:.cpp=.o))
 OBJ_POOL_UTIL    = $(addprefix $(OBJDIR)/,$(SRC_POOL_UTIL:.cpp=.o))
 OBJ_PRJ_UTIL     = $(addprefix $(OBJDIR)/,$(SRC_PRJ_UTIL:.cpp=.o))
-OBJ_POOL_PRJ_MGR = $(addprefix $(OBJDIR)/,$(SRC_POOL_PRJ_MGR:.cpp=.o) $(OBJ_RES))
+OBJ_POOL_PRJ_MGR = $(addprefix $(OBJDIR)/,$(SRC_POOL_PRJ_MGR:.cpp=.o)) $(OBJ_RES)
 OBJ_PGM_TEST     = $(addprefix $(OBJDIR)/,$(SRC_PGM_TEST:.cpp=.o))
 OBJ_GEN_PKG      = $(addprefix $(OBJDIR)/,$(SRC_GEN_PKG:.cpp=.o))
 
@@ -622,11 +622,11 @@ ifeq ($(OS),Windows_NT)
 	LDFLAGS_OCE += -lTKV3d
 endif
 
-SRC_RES =
+OBJ_RES =
 ifeq ($(OS),Windows_NT)
 	SRC_RES = src/horizon-pool-prj-mgr.rc
+	OBJ_RES = $(addprefix $(OBJDIR)/,$(SRC_RES:.rc=.res))
 endif
-OBJ_RES = $(addprefix $(OBJDIR)/,$(SRC_RES:.rc=.res))
 
 src/preferences/color_presets.json: $(wildcard src/preferences/color_presets/*)
 	python3 scripts/make_color_presets.py $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -675,25 +675,16 @@ $(OBJDIR)/%.o: %.cpp
 	$(ECHO) " $@"
 	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) $< -o $@
 
+$(OBJ_ROUTER): INC += $(INC_ROUTER)
+
+$(OBJ_OCE): INC += $(INC_OCE)
+
 $(PICOBJDIR)/%.oshared: %.cpp
 	$(QUIET)$(MKDIR) $(dir $@)
 	$(ECHO) " $@"
 	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) -fPIC $< -o $@
 
-$(OBJ_ROUTER): $(OBJDIR)/%.o: %.cpp
-	$(QUIET)$(MKDIR) $(dir $@)
-	$(ECHO) " $@"
-	$(QUIET)$(CXX) -c $(INC) $(INC_ROUTER) $(CXXFLAGS) $< -o $@
-
-$(OBJ_OCE): $(OBJDIR)/%.o: %.cpp
-	$(QUIET)$(MKDIR) $(dir $@)
-	$(ECHO) " $@"
-	$(QUIET)$(CXX) -c $(INC) $(INC_OCE) $(CXXFLAGS) $< -o $@
-
-$(OBJ_PYTHON): $(PICOBJDIR)/%.oshared: %.cpp
-	$(QUIET)$(MKDIR) $(dir $@)
-	$(ECHO) " $@"
-	$(QUIET)$(CXX) -c -fPIC $(INC) $(INC_PYTHON) $(CXXFLAGS) $< -o $@
+$(OBJ_PYTHON): INC += $(INC_PYTHON)
 
 $(OBJ_RES): $(OBJDIR)/%.res: %.rc
 	$(QUIET)$(MKDIR) $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ OBJ_SHARED = $(SRC_SHARED:.cpp=.oshared)
 
 INC_ROUTER = -I3rd_party/router/include/ -I3rd_party/router -I3rd_party
 INC_OCE = -I/opt/opencascade/inc/ -I/mingw64/include/oce/ -I/usr/include/oce -I/usr/include/opencascade -I${CASROOT}/include/opencascade -I/usr/local/include/OpenCASCADE
-INC_PYTHON = $(shell pkg-config --cflags python3)
+INC_PYTHON = $(shell $(PKGCONFIG) --cflags python3)
 LDFLAGS_OCE = -L /opt/opencascade/lib/ -L${CASROOT}/lib -lTKSTEP  -lTKernel  -lTKXCAF -lTKXSBase -lTKBRep -lTKCDF -lTKXDESTEP -lTKLCAF -lTKMath -lTKMesh -lTKTopAlgo -lTKPrim -lTKBO -lTKG3d
 ifeq ($(OS),Windows_NT)
 	LDFLAGS_OCE += -lTKV3d

--- a/Makefile
+++ b/Makefile
@@ -592,6 +592,8 @@ SRC_SHARED_GEN = $(SRC_COMMON_GEN)
 OBJDIR           = $(BUILDDIR)/obj
 GENDIR           = $(BUILDDIR)/gen
 MKDIR            = mkdir -p
+QUIET            = @
+ECHO             = @echo
 
 # Object files
 OBJ_ALL          = $(addprefix $(OBJDIR)/,$(SRC_ALL:.cpp=.o))
@@ -630,64 +632,80 @@ src/preferences/color_presets.json: $(wildcard src/preferences/color_presets/*)
 	python3 scripts/make_color_presets.py $^ > $@
 
 $(BUILDDIR)/gen/resources.cpp: imp.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies imp.gresource.xml |  while read line; do echo "src/$$line"; done)
-	$(MKDIR) $(dir $@)
-	$(GLIB_COMPILE_RESOURCES) imp.gresource.xml --target=$@ --sourcedir=src --generate-source
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(GLIB_COMPILE_RESOURCES) imp.gresource.xml --target=$@ --sourcedir=src --generate-source
 
 $(BUILDDIR)/gen/version_gen.cpp: $(wildcard .git/HEAD .git/index) version.py make_version.py
-	$(MKDIR) $(dir $@)
-	python3 make_version.py $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)python3 make_version.py $@
 
 $(BUILDDIR)/horizon-imp: $(OBJ_COMMON) $(OBJ_ROUTER) $(OBJ_OCE) $(OBJ_IMP)
-	$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(LDFLAGS_OCE) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0 epoxy cairomm-pdf-1.0 librsvg-2.0 libzmq) -lpodofo -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(LDFLAGS_OCE) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0 epoxy cairomm-pdf-1.0 librsvg-2.0 libzmq) -lpodofo -o $@
 
 $(BUILDDIR)/horizon-pool: $(OBJ_COMMON) $(OBJ_POOL_UTIL)
-	$(CXX) $^ $(LDFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0) -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0) -o $@
 
 $(BUILDDIR)/horizon-prj: $(OBJ_COMMON) $(OBJ_PRJ_UTIL)
-	$(CXX) $^ $(LDFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
 
 $(BUILDDIR)/horizon-eda: $(OBJ_COMMON) $(OBJ_POOL_PRJ_MGR) $(OBJ_RES)
-	$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0 epoxy libzmq libcurl libgit2) -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) gtkmm-3.0 epoxy libzmq libcurl libgit2) -o $@
 
 $(BUILDDIR)/horizon-pgm-test: $(OBJ_COMMON) $(OBJ_PGM_TEST)
-	$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(LDFLAGS_GUI) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
 
 $(BUILDDIR)/horizon-gen-pkg: $(OBJ_COMMON) $(OBJ_GEN_PKG)
-	$(CXX) $^ $(LDFLAGS) $(INC) $(CXXFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(INC) $(CXXFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) glibmm-2.4 giomm-2.4) -o $@
 
 $(BUILDDIR)/horizon.so: $(OBJ_PYTHON) $(OBJ_SHARED)
-	$(CXX) $^ $(LDFLAGS) $(INC) $(CXXFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) python3 glibmm-2.4 giomm-2.4) -lpodofo -shared -o $@
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) $^ $(LDFLAGS) $(INC) $(CXXFLAGS) $(shell $(PKGCONFIG) --libs $(LIBS_COMMON) python3 glibmm-2.4 giomm-2.4) -lpodofo -shared -o $@
 
 $(OBJ_ALL): $(OBJDIR)/%.o: %.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(CXXFLAGS) $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) $< -o $@
 
 $(GENDIR)/%.o: $(GENDIR)/%.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(CXXFLAGS) $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/%.oshared: %.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(CXXFLAGS) -fPIC $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) -fPIC $< -o $@
 
 $(GENDIR)/%.oshared: $(GENDIR)/%.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(CXXFLAGS) -fPIC $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(CXXFLAGS) -fPIC $< -o $@
 
 $(OBJ_ROUTER): $(OBJDIR)/%.o: %.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(INC_ROUTER) $(CXXFLAGS) $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(INC_ROUTER) $(CXXFLAGS) $< -o $@
 
 $(OBJ_OCE): $(OBJDIR)/%.o: %.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c $(INC) $(INC_OCE) $(CXXFLAGS) $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c $(INC) $(INC_OCE) $(CXXFLAGS) $< -o $@
 
 $(OBJ_PYTHON): $(OBJDIR)/%.o: %.cpp
-	$(MKDIR) $(dir $@)
-	$(CXX) -c -fPIC $(INC) $(INC_PYTHON) $(CXXFLAGS) $< -o $@
+	$(QUIET)$(MKDIR) $(dir $@)
+	$(ECHO) " $@"
+	$(QUIET)$(CXX) -c -fPIC $(INC) $(INC_PYTHON) $(CXXFLAGS) $< -o $@
 
 $(OBJ_RES): $(OBJDIR)/%.res: %.rc
-	$(MKDIR) $(dir $@)
+	$(QUIET)$(MKDIR) $(dir $@)
 	windres $< -O coff -o $@
 
 clean: clean_router clean_oce clean_res

--- a/make_bindist.sh
+++ b/make_bindist.sh
@@ -2,7 +2,7 @@
 DISTDIR=dist/horizon
 rm -rf dist
 mkdir -p $DISTDIR
-cp horizon-* $DISTDIR
+cp build/horizon-* $DISTDIR
 strip $DISTDIR/horizon-*
 LIBS=(
 	libstdc++-6.dll\


### PR DESCRIPTION
# Summary
This pull request allows writing compiler output files to an out-of-source directory. It can be useful when comparing behavior of the program in different branches for example. Also keeps source tree listings a bit cleaner.

The intention is to not touch the source directory when building. A separate build tree is created and populated with object files. It has the same directory structure as the source tree.

# Examples
Builds in a directory named "build":
`make`
    
Build in "build-nodebug" without debugging information:
` make DEBUG= BUILDDIR=build-nodebug`
    
Build in a directory named by the git tag:
``` make BUILDDIR=build-`git describe --always --tags` ```
    
Build in source tree (old behavior):
`make BUILDDIR=. OBJDIR=.`

This pull request also decreases build verbosity by default. `make QUIET=` can be used to get verbose output with full compiler command lines.