### PR TITLE
map script theta symbol from unicode to hershey

### DIFF
--- a/src/util/text_data.cpp
+++ b/src/util/text_data.cpp
@@ -158,6 +158,8 @@ static unsigned int codepoint_to_hershey(gunichar c, TextData::Font font)
         case 0x2126: // U+2126 OHM SIGN
         case 0x3a9:  // U+03A9 GREEK CAPITAL LETTER OMEGA
             return 550;
+        case 0x3d1: // U+03D1 GREEK THETA SYMBOL
+            return 634;
         case 0xd7: // U+00D7 MULTIPLICATION SIGN
             return 727;
         case 0xa0: // U+00A0 NO-BREAK SPACE


### PR DESCRIPTION
So `ϑ` can be used for temperature, e.g. in thermistor( symbol)s.