### PR TITLE
mitigate compile error reported by clang version 6.0.1

### DIFF
--- a/src/imp/rules/rules_window.cpp
+++ b/src/imp/rules/rules_window.cpp
@@ -272,7 +272,7 @@ RulesWindow::RulesWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builde
                     for (const auto &path : it_err.error_polygons) {
                         ClipperLib::IntPoint last = path.back();
                         for (const auto &pt : path) {
-                            annotation->draw_line({last.X, last.Y}, {pt.X, pt.Y}, ColorP::FROM_LAYER, .01_mm);
+                            annotation->draw_line(Coordf(last.X, last.Y), Coordf(pt.X, pt.Y), ColorP::FROM_LAYER, .01_mm);
                             last = pt;
                         }
                     }


### PR DESCRIPTION
Clang does not compile `rules_window.cpp` on my system. Probably since 7ef2d9c7.

```
$ c++ -v
FreeBSD clang version 6.0.1 (tags/RELEASE_601/final 335540) (based on LLVM 6.0.1)
```

```
src/imp/rules/rules_window.cpp:275:52: error: non-constant-expression cannot be narrowed from type 'ClipperLib::cInt' (aka 'long long') to 'float' in initializer list [-Wc++11-narrowing]
                            annotation->draw_line({last.X, last.Y}, {pt.X, pt.Y}, ColorP::FROM_LAYER, .01_mm);
```

The file compiles without errors and warnings with this patch.
