### PR TITLE
Angle spinbox improvements

### DIFF
--- a/src/property_panels/property_editor.hpp
+++ b/src/property_panels/property_editor.hpp
@@ -207,9 +207,6 @@ protected:
 private:
     Gtk::SpinButton *sp = nullptr;
     PropertyValueInt value;
-    bool sp_output();
-    void changed();
-    int sp_input(double *v);
 };
 
 class PropertyEditorStringMultiline : public PropertyEditor {

--- a/src/widgets/spin_button_angle.cpp
+++ b/src/widgets/spin_button_angle.cpp
@@ -43,7 +43,7 @@ int SpinButtonAngle::on_input(double *v)
         if (d < 0) {
             d += 360.0;
         }
-        va = (d / 360.0) * 65536;
+        va = std::round((d / 360.0) * 65536);
         *v = va;
     }
     catch (const std::exception &e) {

--- a/src/widgets/spin_button_angle.cpp
+++ b/src/widgets/spin_button_angle.cpp
@@ -12,6 +12,12 @@ SpinButtonAngle::SpinButtonAngle() : Gtk::SpinButton()
     double step = (1.0 / 360.0) * 65536;
     double page = (15.0 / 360.0) * 65536;
     set_increments(step, page);
+
+    auto attributes_list = pango_attr_list_new();
+    auto attribute_font_features = pango_attr_font_features_new("tnum 1");
+    pango_attr_list_insert(attributes_list, attribute_font_features);
+    gtk_entry_set_attributes(GTK_ENTRY(gobj()), attributes_list);
+    pango_attr_list_unref(attributes_list);
 }
 
 bool SpinButtonAngle::on_output()

--- a/src/widgets/spin_button_angle.cpp
+++ b/src/widgets/spin_button_angle.cpp
@@ -27,7 +27,8 @@ bool SpinButtonAngle::on_output()
 
 int SpinButtonAngle::on_input(double *v)
 {
-    auto txt = get_text();
+    auto txt = get_text().raw();
+    std::replace(txt.begin(), txt.end(), ',', '.');
     int64_t va = 0;
     try {
         va = (std::stod(txt) / 360.0) * 65536;

--- a/src/widgets/spin_button_angle.cpp
+++ b/src/widgets/spin_button_angle.cpp
@@ -9,7 +9,9 @@ SpinButtonAngle::SpinButtonAngle() : Gtk::SpinButton()
     set_range(0, 65536);
     set_wrap(true);
     set_width_chars(6);
-    set_increments(4096, 4096);
+    double step = (1.0 / 360.0) * 65536;
+    double page = (15.0 / 360.0) * 65536;
+    set_increments(step, page);
 }
 
 bool SpinButtonAngle::on_output()

--- a/src/widgets/spin_button_angle.cpp
+++ b/src/widgets/spin_button_angle.cpp
@@ -33,12 +33,25 @@ int SpinButtonAngle::on_input(double *v)
     std::replace(txt.begin(), txt.end(), ',', '.');
     int64_t va = 0;
     try {
-        va = (std::stod(txt) / 360.0) * 65536;
+        double d = std::fmod(std::stod(txt), 360.0);
+        if (d < 0) {
+            d += 360.0;
+        }
+        va = (d / 360.0) * 65536;
         *v = va;
     }
     catch (const std::exception &e) {
         return false;
     }
     return true;
+}
+
+void SpinButtonAngle::on_wrapped()
+{
+    auto adj = get_adjustment();
+    if (adj->get_value() == adj->get_upper()) {
+        // Wrap 0 -> maximum
+        adj->set_value(std::floor(65535 / adj->get_step_increment()) * adj->get_step_increment());
+    }
 }
 } // namespace horizon

--- a/src/widgets/spin_button_angle.hpp
+++ b/src/widgets/spin_button_angle.hpp
@@ -10,5 +10,6 @@ public:
 protected:
     virtual int on_input(double *new_value);
     virtual bool on_output();
+    virtual void on_wrapped();
 };
 } // namespace horizon


### PR DESCRIPTION
I noticed the angle spinbox didn't take decimal places when the locale's decimal separator is a comma. While fixing this I changed a few other things:

* The increments with the arrow keys/scrolling are now 1°, with PgUp/PgDn 15°. This should be more useful than the current behaviour.
* You can now directly enter negative angles and angles > 360°. Especially negative angles are useful sometimes.

Because I did neither find a way to let Gtk consider the upper and lower limit to be identical, nor how to easily check if the last increment was a step or a page increment, the wrapping behaviour is now slightly inconsequential: with both kinds of increments, it always wraps to 0° or 359°. I consider this issue to be pretty minor, though.