### PR TITLE
Fix text placement when smashing flipped rotated packages

### DIFF
--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -762,6 +762,9 @@ void Board::smash_package(BoardPackage *pkg)
             x.from_smash = true;
             x.overridden = true;
             x.placement = pkg->placement;
+            if (x.placement.mirror) {
+                x.placement.invert_angle();
+            }
             x.placement.accumulate(it.second.placement);
             x.text = it.second.text;
             x.layer = it.second.layer;


### PR DESCRIPTION
Just a small thing: When smashing a flipped and rotated package, the positions and angles of its text fields aren't kept (silkscreen texts on both layers are affected):
![smash](https://user-images.githubusercontent.com/11243448/71120364-89676d80-21dc-11ea-9992-f9f6ba83f359.gif)

This PR should fix this.