### PR TITLE
Avoid space in footprint generator pad names

### DIFF
--- a/3rd_party/footag/wiz.c
+++ b/3rd_party/footag/wiz.c
@@ -272,7 +272,7 @@ void footag_gridnames(
                         snprintf(
                                 p[i].name,
                                 NELEM(p[0].name),
-                                "%2s%d",
+                                "%s%d",
                                 rowname,
                                 (col+1) % 1000
                         );


### PR DESCRIPTION
Pad names with one letter in grid style footprints got names such
as `" A9"`, `" A10"`, `"AB9"`, `"AB10"` etc. This commit avoids the prefix
space character.