### PR TITLE
SpinButtonDim parses mil

### DIFF
--- a/src/widgets/spin_button_dim.cpp
+++ b/src/widgets/spin_button_dim.cpp
@@ -60,6 +60,17 @@ static Operation op_from_char(char c)
     }
 }
 
+static bool op_is_mul(Operation op)
+{
+    switch (op) {
+    case Operation::MUL:
+    case Operation::DIV:
+        return true;
+    default:
+        return false;
+    }
+}
+
 
 static int64_t parse_str(const Glib::ustring &s)
 {
@@ -108,11 +119,11 @@ static int64_t parse_str(const Glib::ustring &s)
                 value = 0;
                 state = State::SIGN;
             }
-            else if (c == 'i' && operation == Operation::INVALID) {
+            else if (c == 'i' && !op_is_mul(operation)) {
                 value *= 25.4;
                 state = State::UNIT;
             }
-            else if (c == 'm' && operation == Operation::INVALID) {
+            else if (c == 'm' && !op_is_mul(operation)) {
                 state = State::UNIT_M;
             }
             break;
@@ -131,11 +142,11 @@ static int64_t parse_str(const Glib::ustring &s)
                 value = 0;
                 state = State::SIGN;
             }
-            else if (c == 'i' && operation == Operation::INVALID) {
+            else if (c == 'i' && !op_is_mul(operation)) {
                 value *= 25.4;
                 state = State::UNIT;
             }
-            else if (c == 'm' && operation == Operation::INVALID) {
+            else if (c == 'm' && !op_is_mul(operation)) {
                 state = State::UNIT_M;
             }
             break;

--- a/src/widgets/spin_button_dim.cpp
+++ b/src/widgets/spin_button_dim.cpp
@@ -67,7 +67,7 @@ static int64_t parse_str(const Glib::ustring &s)
     int64_t value = 0;
     int64_t mul = 1000000;
     int sign = 1;
-    enum class State { SIGN, INT, DECIMAL, UNIT };
+    enum class State { SIGN, INT, DECIMAL, UNIT, UNIT_M };
     auto state = State::SIGN;
     bool parsed_any = false;
     Operation operation = Operation::INVALID;
@@ -112,6 +112,9 @@ static int64_t parse_str(const Glib::ustring &s)
                 value *= 25.4;
                 state = State::UNIT;
             }
+            else if (c == 'm' && operation == Operation::INVALID) {
+                state = State::UNIT_M;
+            }
             break;
 
         case State::DECIMAL:
@@ -132,7 +135,17 @@ static int64_t parse_str(const Glib::ustring &s)
                 value *= 25.4;
                 state = State::UNIT;
             }
+            else if (c == 'm' && operation == Operation::INVALID) {
+                state = State::UNIT_M;
+            }
             break;
+
+        case State::UNIT_M:
+            if (c == 'i') {
+                value *= 25.4 / 1000.0;
+            }
+            state = State::UNIT;
+            /* fall through */
 
         case State::UNIT:
             if (op_from_char(c) != Operation::INVALID && operation == Operation::INVALID) {


### PR DESCRIPTION
Allows typing things like `4.5 mil` (in addition to `mm` and `inch`) into dimension spin buttons. It is not the neatest patch, but it works.