### PR TITLE
Copy placement tool improvements

### DIFF
--- a/src/board/board.hpp
+++ b/src/board/board.hpp
@@ -52,6 +52,7 @@ public:
     void disconnect_package(BoardPackage *pkg);
 
     void smash_package(BoardPackage *pkg);
+    void copy_package_silkscreen_texts(BoardPackage *dest, const BoardPackage *src);
     void unsmash_package(BoardPackage *pkg);
     void smash_package_silkscreen_graphics(BoardPackage *pkg);
 

--- a/src/core/tool_copy_placement.cpp
+++ b/src/core/tool_copy_placement.cpp
@@ -101,6 +101,18 @@ ToolResponse ToolCopyPlacement::update(const ToolArgs &args)
                             it->placement.accumulate(rp);
                             it->flip = it->placement.mirror;
                         }
+
+                        if (this_ref_pkg->alternate_package == it->alternate_package
+                            && this_ref_pkg->pool_package == it->pool_package) {
+                            if (this_ref_pkg->omit_silkscreen && it->smashed) {
+                                core.b->get_board()->unsmash_package(it);
+                            }
+                            it->omit_silkscreen = this_ref_pkg->omit_silkscreen;
+
+                            if (this_ref_pkg->smashed) {
+                                core.b->get_board()->copy_package_silkscreen_texts(it, this_ref_pkg);
+                            }
+                        }
                     }
                 }
 

--- a/src/util/placement.cpp
+++ b/src/util/placement.cpp
@@ -24,7 +24,7 @@ void Placement::accumulate(const Placement &p)
     if (angle == 0) {
         // nop
     }
-    if (angle == 16384) {
+    else if (angle == 16384) {
         q.shift.y = p.shift.x;
         q.shift.x = -p.shift.y;
     }

--- a/src/util/placement.cpp
+++ b/src/util/placement.cpp
@@ -17,6 +17,43 @@ json Placement::serialize() const
     return j;
 }
 
+void Placement::make_relative(const Placement &to)
+{
+    mirror ^= to.mirror;
+    shift -= to.shift;
+
+    if (to.mirror) {
+        shift.x = -shift.x;
+    }
+    angle -= to.angle;
+    while (angle < 0) {
+        angle += 65536;
+    }
+    angle %= 65536;
+
+    Coordi s = shift;
+    if (to.angle == 0) {
+        // nop
+    }
+    else if (to.angle == 16384) {
+        shift.y = -s.x;
+        shift.x = s.y;
+    }
+    else if (to.angle == 32768) {
+        shift.y = -s.y;
+        shift.x = -s.x;
+    }
+    else if (to.angle == 49152) {
+        shift.y = s.x;
+        shift.x = -s.y;
+    }
+    else {
+        double af = -(to.angle / 65536.0) * 2 * M_PI;
+        shift.x = s.x * cos(af) - s.y * sin(af);
+        shift.y = s.x * sin(af) + s.y * cos(af);
+    }
+}
+
 void Placement::accumulate(const Placement &p)
 {
     Placement q = p;

--- a/src/util/placement.hpp
+++ b/src/util/placement.hpp
@@ -68,6 +68,7 @@ public:
     {
         shift = {0, 0}, angle = 0, mirror = false;
     }
+    void make_relative(const Placement &to);
     void accumulate(const Placement &p);
     void invert_angle();
     void set_angle(int a);


### PR DESCRIPTION
While looking into #324, I noticed that the copy placement tool wasn't working properly for packages on the bottom layer. With this PR, the tool should show the expected behaviour in all cases (top -> top, top -> bottom, bottom -> bottom, bottom -> top). Please have a thorough look at it nonetheless to ensure I didn't miss some edge case.

On top of that, copy placement now also copies silkscreen texts from the reference package if reference and target use the same package and the reference is smashed. The ‘omit silkscreen’ setting is also copied across.

I added Placement::make_relative() as an inverse to Placement::accumulate() to hopefully make the code a bit more clear. However, because flipping a group also requires inverting angles (and not just mirroring positions), some special cases are necessary.