### PR TITLE
Add component group and tag to schematic and board HUD

### DIFF
--- a/src/imp/imp.cpp
+++ b/src/imp/imp.cpp
@@ -924,6 +924,12 @@ std::string ImpBase::get_hud_text_for_component(const Component *comp)
             s += "<a href=\"" + Glib::Markup::escape_text(part->get_datasheet()) + "\" title=\""
                  + Glib::Markup::escape_text(Glib::Markup::escape_text(part->get_datasheet())) + "\">Datasheet</a>\n";
 
+        const auto block = core.r->get_block();
+        if (comp->group)
+            s += "Group: " + Glib::Markup::escape_text(block->group_names.at(comp->group)) + "\n";
+        if (comp->tag)
+            s += "Tag: " + Glib::Markup::escape_text(block->tag_names.at(comp->tag)) + "\n";
+
         trim(s);
         return s;
     }

--- a/src/imp/imp.cpp
+++ b/src/imp/imp.cpp
@@ -926,9 +926,9 @@ std::string ImpBase::get_hud_text_for_component(const Component *comp)
 
         const auto block = core.r->get_block();
         if (comp->group)
-            s += "Group: " + Glib::Markup::escape_text(block->group_names.at(comp->group)) + "\n";
+            s += "Group: " + Glib::Markup::escape_text(block->get_group_name(comp->group)) + "\n";
         if (comp->tag)
-            s += "Tag: " + Glib::Markup::escape_text(block->tag_names.at(comp->tag)) + "\n";
+            s += "Tag: " + Glib::Markup::escape_text(block->get_tag_name(comp->tag)) + "\n";
 
         trim(s);
         return s;

--- a/src/imp/imp_schematic.cpp
+++ b/src/imp/imp_schematic.cpp
@@ -569,7 +569,14 @@ std::string ImpSchematic::get_hud_text(std::set<SelectableRef> &sel)
     if (sel_count_type(sel, ObjectType::SCHEMATIC_SYMBOL) == 1) {
         const auto &sym = core_schematic.get_sheet()->symbols.at(sel_find_one(sel, ObjectType::SCHEMATIC_SYMBOL));
         s += "<b>Symbol " + sym.component->refdes + "</b>\n";
-        s += get_hud_text_for_component(sym.component);
+        s += get_hud_text_for_component(sym.component) + "\n";
+
+        auto block = core_schematic.get_block();
+        if (sym.component->group)
+            s += "Group: " + Glib::Markup::escape_text(block->group_names[sym.component->group]) + "\n";
+        if (sym.component->tag)
+            s += "Tag: " + Glib::Markup::escape_text(block->tag_names[sym.component->tag]) + "\n";
+
         sel_erase_type(sel, ObjectType::SCHEMATIC_SYMBOL);
     }
     trim(s);

--- a/src/imp/imp_schematic.cpp
+++ b/src/imp/imp_schematic.cpp
@@ -569,14 +569,7 @@ std::string ImpSchematic::get_hud_text(std::set<SelectableRef> &sel)
     if (sel_count_type(sel, ObjectType::SCHEMATIC_SYMBOL) == 1) {
         const auto &sym = core_schematic.get_sheet()->symbols.at(sel_find_one(sel, ObjectType::SCHEMATIC_SYMBOL));
         s += "<b>Symbol " + sym.component->refdes + "</b>\n";
-        s += get_hud_text_for_component(sym.component) + "\n";
-
-        auto block = core_schematic.get_block();
-        if (sym.component->group)
-            s += "Group: " + Glib::Markup::escape_text(block->group_names[sym.component->group]) + "\n";
-        if (sym.component->tag)
-            s += "Tag: " + Glib::Markup::escape_text(block->tag_names[sym.component->tag]) + "\n";
-
+        s += get_hud_text_for_component(sym.component);
         sel_erase_type(sel, ObjectType::SCHEMATIC_SYMBOL);
     }
     trim(s);


### PR DESCRIPTION
This PR adds the group and tag to the schematic editor's HUD:
![screenshot](https://user-images.githubusercontent.com/11243448/73757047-df7e7900-4768-11ea-8af9-1e67a65ed1d8.png)

This is especially useful if a symbol's value is hidden or the schematic if is too crowded, so the group and tag names displayed in the value field wouldn't be readable.

Am I right in assuming that adding this information to the board editor would be non-trivial, since the block and consequently the group and tag names aren't available there?