### PR TITLE
add "do not populate" component marking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ SRC_IMP = \
 	src/core/tools/tool_smash_silkscreen_graphics.cpp\
 	src/core/tools/tool_renumber_pads.cpp\
 	src/core/tools/tool_fix.cpp\
+	src/core/tools/tool_nopopulate.cpp\
 	src/core/tools/tool_polygon_to_line_loop.cpp\
 	src/document/documents.cpp\
 	src/core/clipboard.cpp\

--- a/src/block/block.cpp
+++ b/src/block/block.cpp
@@ -303,6 +303,9 @@ std::map<const Part *, BOMRow> Block::get_BOM(const BOMExportSettings &settings)
 {
     std::map<const Part *, BOMRow> rows;
     for (const auto &it : components) {
+        if (it.second.nopopulate && !settings.include_nopopulate) {
+            continue;
+        }
         if (it.second.part) {
             const Part *part;
             if (settings.concrete_parts.count(it.second.part->uuid))

--- a/src/block/bom_export_settings.cpp
+++ b/src/block/bom_export_settings.cpp
@@ -11,7 +11,8 @@ const LutEnumStr<BOMExportSettings::CSVSettings::Order> bom_order_lut = {
 };
 
 BOMExportSettings::BOMExportSettings(const json &j, Pool &pool)
-    : csv_settings(j.at("csv_settings")), output_filename(j.at("output_filename").get<std::string>())
+    : csv_settings(j.at("csv_settings")), output_filename(j.at("output_filename").get<std::string>()),
+      include_nopopulate(j.value("include_nopopulate", true))
 {
     if (j.count("orderable_MPNs")) {
         const json &o = j["orderable_MPNs"];
@@ -54,6 +55,8 @@ json BOMExportSettings::serialize() const
     for (const auto &it : concrete_parts) {
         j["concrete_parts"][(std::string)it.first] = (std::string)it.second->uuid;
     }
+    if (!include_nopopulate)
+        j["include_nopopulate"] = false;
     return j;
 }
 

--- a/src/block/bom_export_settings.hpp
+++ b/src/block/bom_export_settings.hpp
@@ -35,5 +35,7 @@ public:
     CSVSettings csv_settings;
 
     std::string output_filename;
+
+    bool include_nopopulate = true;
 };
 } // namespace horizon

--- a/src/block/component.cpp
+++ b/src/block/component.cpp
@@ -35,7 +35,7 @@ Connection::Connection(const json &j, Block *block)
 
 Component::Component(const UUID &uu, const json &j, Pool &pool, Block *block)
     : uuid(uu), entity(pool.get_entity(j.at("entity").get<std::string>())), refdes(j.at("refdes").get<std::string>()),
-      value(j.at("value").get<std::string>())
+      value(j.at("value").get<std::string>()), nopopulate(j.value("nopopulate", false))
 {
     if (j.count("part")) {
         part = pool.get_part(j.at("part").get<std::string>());
@@ -158,6 +158,9 @@ json Component::serialize() const
     j["group"] = (std::string)group;
     j["tag"] = (std::string)tag;
     j["connections"] = json::object();
+    if (nopopulate) {
+        j["nopopulate"] = true;
+    }
     if (part != nullptr) {
         j["part"] = part->uuid;
     }

--- a/src/block/component.hpp
+++ b/src/block/component.hpp
@@ -50,6 +50,7 @@ public:
     std::string value;
     UUID group;
     UUID tag;
+    bool nopopulate = false;
 
     /**
      * which Nins are connected to which Net

--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -1011,6 +1011,10 @@ std::map<const BoardPackage *, PnPRow> Board::get_PnP(const PnPExportSettings &s
 {
     std::map<const BoardPackage *, PnPRow> r;
     for (const auto &it : packages) {
+        if (it.second.component->nopopulate && !settings.include_nopopulate) {
+            continue;
+        }
+
         PnPRow row;
         row.refdes = it.second.component->refdes;
         row.package = it.second.package.name;

--- a/src/board/pnp_export_settings.cpp
+++ b/src/board/pnp_export_settings.cpp
@@ -9,7 +9,8 @@ const LutEnumStr<PnPExportSettings::Mode> PnPExportSettings::mode_lut = {
 };
 
 PnPExportSettings::PnPExportSettings(const json &j)
-    : mode(mode_lut.lookup(j.at("mode"))), output_directory(j.at("output_directory").get<std::string>()),
+    : mode(mode_lut.lookup(j.at("mode"))), include_nopopulate(j.value("include_nopopulate", true)),
+      output_directory(j.at("output_directory").get<std::string>()),
       filename_top(j.at("filename_top").get<std::string>()),
       filename_bottom(j.at("filename_bottom").get<std::string>()),
       filename_merged(j.at("filename_merged").get<std::string>())
@@ -28,6 +29,9 @@ json PnPExportSettings::serialize() const
 {
     json j;
     j["mode"] = mode_lut.lookup_reverse(mode);
+    if (!include_nopopulate) {
+        j["include_nopopulate"] = false;
+    }
     j["output_directory"] = output_directory;
     j["filename_top"] = filename_top;
     j["filename_bottom"] = filename_bottom;

--- a/src/board/pnp_export_settings.hpp
+++ b/src/board/pnp_export_settings.hpp
@@ -24,6 +24,8 @@ public:
 
     static const LutEnumStr<Mode> mode_lut;
 
+    bool include_nopopulate = true;
+
     std::string output_directory;
 
     std::string filename_top;

--- a/src/canvas/appearance.cpp
+++ b/src/canvas/appearance.cpp
@@ -35,6 +35,7 @@ Appearance::Appearance()
     colors[ColorP::SEARCH_CURRENT] = {1, 0, 1};
     colors[ColorP::SHADOW] = {.3, .3, .3};
     colors[ColorP::CONNECTION_LINE] = {.7, 0, .6};
+    colors[ColorP::NOPOPULATE_X] = {.8, .4, .4};
 
     layer_colors[BoardLayers::TOP_NOTES] = {1, 1, 1};
     layer_colors[BoardLayers::L_OUTLINE] = {.6, .6, 0};

--- a/src/canvas/canvas.hpp
+++ b/src/canvas/canvas.hpp
@@ -79,11 +79,11 @@ protected:
 
     std::map<ObjectRef, std::map<int, std::pair<size_t, size_t>>> object_refs;
     std::vector<ObjectRef> object_refs_current;
-    void render(const class Symbol &sym, bool on_sheet = false, bool smashed = false);
+    void render(const class Symbol &sym, bool on_sheet = false, bool smashed = false, ColorP co = ColorP::FROM_LAYER);
     void render(const class Junction &junc, bool interactive = true, ObjectType mode = ObjectType::INVALID);
-    void render(const class Line &line, bool interactive = true);
-    void render(const class SymbolPin &pin, bool interactive = true);
-    void render(const class Arc &arc, bool interactive = true);
+    void render(const class Line &line, bool interactive = true, ColorP co = ColorP::FROM_LAYER);
+    void render(const class SymbolPin &pin, bool interactive = true, ColorP co = ColorP::FROM_LAYER);
+    void render(const class Arc &arc, bool interactive = true, ColorP co = ColorP::FROM_LAYER);
     void render(const class Sheet &sheet);
     void render(const class SchematicSymbol &sym);
     void render(const class LineNet &line);
@@ -92,9 +92,9 @@ protected:
     void render(const class Warning &warn);
     void render(const class PowerSymbol &sym);
     void render(const class BusRipper &ripper);
-    void render(const class Text &text, bool interactive = true);
+    void render(const class Text &text, bool interactive = true, ColorP co = ColorP::FROM_LAYER);
     void render(const class Padstack &padstack, bool interactive = true);
-    void render(const class Polygon &polygon, bool interactive = true);
+    void render(const class Polygon &polygon, bool interactive = true, ColorP co = ColorP::FROM_LAYER);
     void render(const class Shape &shape, bool interactive = true);
     void render(const class Hole &hole, bool interactive = true);
     void render(const class Package &package, bool interactive = true, bool smashed = false,

--- a/src/canvas/color_palette.hpp
+++ b/src/canvas/color_palette.hpp
@@ -19,6 +19,7 @@ enum class ColorP {
     DIFFPAIR,
     SHADOW,
     CONNECTION_LINE,
+    NOPOPULATE_X,
     N_COLORS,
     // colors after N_COLORS aren't part of the UBO
     BACKGROUND,

--- a/src/canvas/render.cpp
+++ b/src/canvas/render.cpp
@@ -623,10 +623,12 @@ void Canvas::render(const SchematicSymbol &sym)
 
     if (sym.component->nopopulate) {
         transform = sym.placement;
+        img_auto_line = img_mode;
         draw_line(bb.first - Coordi(0.2_mm, 0.2_mm), bb.second + Coordi(0.2_mm, 0.2_mm), ColorP::NOPOPULATE_X, 0, true,
                   0.2_mm);
         draw_line(Coordi(bb.first.x, bb.second.y) + Coordi(-0.2_mm, 0.2_mm),
                   Coordi(bb.second.x, bb.first.y) + Coordi(0.2_mm, -0.2_mm), ColorP::NOPOPULATE_X, 0, true, 0.2_mm);
+        img_auto_line = false;
         transform.reset();
     }
 }

--- a/src/canvas/render.cpp
+++ b/src/canvas/render.cpp
@@ -611,6 +611,15 @@ void Canvas::render(const SchematicSymbol &sym)
     auto bb = sym.symbol.get_bbox();
     selectables.append(sym.uuid, ObjectType::SCHEMATIC_SYMBOL, {0, 0}, bb.first, bb.second);
     transform.reset();
+
+    if (sym.component && sym.component->nopopulate) {
+        transform = sym.placement;
+        draw_line(bb.first - Coordi(0.2_mm, 0.2_mm), bb.second + Coordi(0.2_mm, 0.2_mm), ColorP::NOPOPULATE_X, 0, true,
+                  0.2_mm);
+        draw_line(Coordi(bb.first.x, bb.second.y) + Coordi(-0.2_mm, 0.2_mm),
+                  Coordi(bb.second.x, bb.first.y) + Coordi(0.2_mm, -0.2_mm), ColorP::NOPOPULATE_X, 0, true, 0.2_mm);
+        transform.reset();
+    }
 }
 
 void Canvas::render(const Text &text, bool interactive)

--- a/src/canvas/shaders/ubo.glsl
+++ b/src/canvas/shaders/ubo.glsl
@@ -1,6 +1,6 @@
 layout (std140) uniform layer_setup
 { 
-	vec3 colors[17];
+	vec3 colors[18];
 	mat3 screenmat;
 	mat3 viewmat;
 	vec3 layer_color;

--- a/src/canvas/triangle.cpp
+++ b/src/canvas/triangle.cpp
@@ -136,7 +136,7 @@ void TriangleRenderer::realize()
 
 class UBOBuffer {
 public:
-    std::array<std::array<float, 4>, 17> colors; // 17==ColorP::N_COLORS, keep in sync with shaders
+    std::array<std::array<float, 4>, 18> colors; // 18==ColorP::N_COLORS, keep in sync with shaders
     std::array<float, 12> screenmat;
     std::array<float, 12> viewmat;
     std::array<float, 3> layer_color;

--- a/src/common/object_descr.cpp
+++ b/src/common/object_descr.cpp
@@ -165,6 +165,7 @@ const std::map<ObjectType, ObjectDescription> object_descriptions = {
                   {ObjectProperty::ID::REFDES, {ObjectProperty::Type::STRING, "Ref. Desig.", 0}},
                   {ObjectProperty::ID::VALUE, {ObjectProperty::Type::STRING, "Value", 2}},
                   {ObjectProperty::ID::MPN, {ObjectProperty::Type::STRING_RO, "MPN", 1}},
+                  {ObjectProperty::ID::NOPOPULATE, {ObjectProperty::Type::BOOL, "Do not pop.", 3}},
           }}},
         {ObjectType::NET,
          {"Net",

--- a/src/common/object_descr.hpp
+++ b/src/common/object_descr.hpp
@@ -72,7 +72,8 @@ public:
         TAG,
         EXPAND,
         OMIT_SILKSCREEN,
-        FIXED
+        FIXED,
+        NOPOPULATE,
     };
     ObjectProperty(Type t, const std::string &l, int o = 0, const std::vector<std::pair<int, std::string>> &its = {})
         : type(t), label(l), enum_items(its), order(o)

--- a/src/core/core_schematic.cpp
+++ b/src/core/core_schematic.cpp
@@ -286,6 +286,13 @@ bool CoreSchematic::get_property(ObjectType type, const UUID &uu, ObjectProperty
                 dynamic_cast<PropertyValueString &>(value).value = "<no part>";
             return true;
 
+        case ObjectProperty::ID::NOPOPULATE:
+            if (block.components.at(uu).part)
+                dynamic_cast<PropertyValueBool &>(value).value = comp->nopopulate;
+            else
+                dynamic_cast<PropertyValueBool &>(value).value = false;
+            return true;
+
         default:
             return false;
         }
@@ -342,6 +349,10 @@ bool CoreSchematic::set_property(ObjectType type, const UUID &uu, ObjectProperty
             if (comp->part)
                 return false;
             comp->value = dynamic_cast<const PropertyValueString &>(value).value;
+            break;
+
+        case ObjectProperty::ID::NOPOPULATE:
+            comp->nopopulate = dynamic_cast<const PropertyValueBool &>(value).value;
             break;
 
         default:

--- a/src/core/create_tool.cpp
+++ b/src/core/create_tool.cpp
@@ -69,6 +69,7 @@
 #include "tools/tool_smash_silkscreen_graphics.hpp"
 #include "tools/tool_renumber_pads.hpp"
 #include "tools/tool_fix.hpp"
+#include "tools/tool_nopopulate.hpp"
 #include "tools/tool_polygon_to_line_loop.hpp"
 
 namespace horizon {
@@ -344,6 +345,10 @@ std::unique_ptr<ToolBase> Core::create_tool(ToolID tool_id)
     case ToolID::FIX:
     case ToolID::UNFIX:
         return std::make_unique<ToolFix>(this, tool_id);
+
+    case ToolID::NOPOPULATE:
+    case ToolID::POPULATE:
+        return std::make_unique<ToolNoPopulate>(this, tool_id);
 
     case ToolID::POLYGON_TO_LINE_LOOP:
         return std::make_unique<ToolPolygonToLineLoop>(this, tool_id);

--- a/src/core/tool_id.hpp
+++ b/src/core/tool_id.hpp
@@ -130,6 +130,8 @@ enum class ToolID {
     RENUMBER_PADS,
     FIX,
     UNFIX,
+    NOPOPULATE,
+    POPULATE,
     POLYGON_TO_LINE_LOOP
 };
 } // namespace horizon

--- a/src/core/tools/tool_nopopulate.cpp
+++ b/src/core/tools/tool_nopopulate.cpp
@@ -1,0 +1,38 @@
+#include "tool_nopopulate.hpp"
+#include "document/idocument_schematic.hpp"
+#include "schematic/schematic.hpp"
+#include <iostream>
+
+namespace horizon {
+
+ToolNoPopulate::ToolNoPopulate(IDocument *c, ToolID tid) : ToolBase(c, tid)
+{
+}
+
+bool ToolNoPopulate::can_begin()
+{
+    for (const auto &it : selection) {
+        if (it.type == ObjectType::SCHEMATIC_SYMBOL) {
+            auto sym = doc.c->get_schematic_symbol(it.uuid);
+            if (sym->component->nopopulate == (tool_id == ToolID::POPULATE))
+                return true;
+        }
+    }
+    return false;
+}
+
+ToolResponse ToolNoPopulate::begin(const ToolArgs &args)
+{
+    for (const auto &it : args.selection) {
+        if (it.type == ObjectType::SCHEMATIC_SYMBOL) {
+            auto sym = doc.c->get_schematic_symbol(it.uuid);
+            sym->component->nopopulate = (tool_id == ToolID::NOPOPULATE);
+        }
+    }
+    return ToolResponse::commit();
+}
+ToolResponse ToolNoPopulate::update(const ToolArgs &args)
+{
+    return ToolResponse();
+}
+} // namespace horizon

--- a/src/core/tools/tool_nopopulate.hpp
+++ b/src/core/tools/tool_nopopulate.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "core/tool.hpp"
+#include <forward_list>
+
+namespace horizon {
+
+class ToolNoPopulate : public ToolBase {
+public:
+    ToolNoPopulate(IDocument *c, ToolID tid);
+    ToolResponse begin(const ToolArgs &args) override;
+    ToolResponse update(const ToolArgs &args) override;
+    bool can_begin() override;
+    bool is_specific() override
+    {
+        return true;
+    }
+
+private:
+};
+} // namespace horizon

--- a/src/imp/action_catalog.cpp
+++ b/src/imp/action_catalog.cpp
@@ -714,6 +714,14 @@ const std::map<std::pair<ActionID, ToolID>, ActionCatalogItem> action_catalog = 
          {"Unfix package", ActionGroup::BOARD, ActionCatalogItem::AVAILABLE_IN_BOARD,
           ActionCatalogItem::FLAGS_DEFAULT}},
 
+        {{ActionID::TOOL, ToolID::NOPOPULATE},
+         {"Mark do not populate", ActionGroup::SCHEMATIC, ActionCatalogItem::AVAILABLE_IN_SCHEMATIC,
+          ActionCatalogItem::FLAGS_DEFAULT}},
+
+        {{ActionID::TOOL, ToolID::POPULATE},
+         {"Mark populate", ActionGroup::SCHEMATIC, ActionCatalogItem::AVAILABLE_IN_SCHEMATIC,
+          ActionCatalogItem::FLAGS_DEFAULT}},
+
         {{ActionID::TOOL, ToolID::POLYGON_TO_LINE_LOOP},
          {"Polygon to line loop", ActionGroup::GRAPHICS, ActionCatalogItem::AVAILABLE_EVERYWHERE,
           ActionCatalogItem::FLAGS_DEFAULT}},
@@ -970,6 +978,8 @@ const LutEnumStr<ToolID> tool_lut = {
         TOOL_LUT_ITEM(RENUMBER_PADS),
         TOOL_LUT_ITEM(FIX),
         TOOL_LUT_ITEM(UNFIX),
+        TOOL_LUT_ITEM(NOPOPULATE),
+        TOOL_LUT_ITEM(POPULATE),
         TOOL_LUT_ITEM(POLYGON_TO_LINE_LOOP),
 };
 } // namespace horizon

--- a/src/imp/bom_export.ui
+++ b/src/imp/bom_export.ui
@@ -129,7 +129,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -164,7 +164,21 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="nopopulate_check">
+                            <property name="label" translatable="yes">Include "do not populate" components</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
                             <property name="top_attach">1</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/src/imp/bom_export_window.cpp
+++ b/src/imp/bom_export_window.cpp
@@ -60,6 +60,7 @@ BOMExportWindow::BOMExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
 {
 
     GET_WIDGET(export_button);
+    GET_WIDGET(nopopulate_check);
     GET_WIDGET(filename_button);
     GET_WIDGET(filename_entry);
     GET_WIDGET(sort_column_combo);
@@ -83,6 +84,13 @@ BOMExportWindow::BOMExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
     export_filechooser.set_project_dir(project_dir);
     export_filechooser.bind_filename(settings->output_filename);
     export_filechooser.signal_changed().connect([this] { s_signal_changed.emit(); });
+
+    nopopulate_check->set_active(settings->include_nopopulate);
+    nopopulate_check->signal_toggled().connect([this] {
+        settings->include_nopopulate = nopopulate_check->get_active();
+        s_signal_changed.emit();
+        update_preview();
+    });
 
     for (const auto &it : bom_column_names) {
         sort_column_combo->append(std::to_string(static_cast<int>(it.first)), it.second);

--- a/src/imp/bom_export_window.cpp
+++ b/src/imp/bom_export_window.cpp
@@ -321,7 +321,9 @@ void BOMExportWindow::update_orderable_MPNs()
             delete ch;
         }
     }
-    auto rows = block->get_BOM(*settings);
+    BOMExportSettings my_settings(*settings);
+    my_settings.include_nopopulate = true;
+    auto rows = block->get_BOM(my_settings);
     for (const auto &row : rows) {
         auto part = row.first;
         if (part->orderable_MPNs.size()) {

--- a/src/imp/bom_export_window.hpp
+++ b/src/imp/bom_export_window.hpp
@@ -42,6 +42,7 @@ private:
     MyExportFileChooser export_filechooser;
 
     Gtk::Button *export_button = nullptr;
+    Gtk::CheckButton *nopopulate_check = nullptr;
     Gtk::ComboBoxText *sort_column_combo = nullptr;
     Gtk::ComboBoxText *sort_order_combo = nullptr;
     Gtk::Revealer *done_revealer = nullptr;

--- a/src/imp/pnp_export.ui
+++ b/src/imp/pnp_export.ui
@@ -101,7 +101,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -118,7 +118,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">3</property>
+                            <property name="top_attach">4</property>
                           </packing>
                         </child>
                         <child>
@@ -135,7 +135,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">4</property>
+                            <property name="top_attach">5</property>
                           </packing>
                         </child>
                         <child>
@@ -145,7 +145,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -155,7 +155,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">3</property>
+                            <property name="top_attach">4</property>
                           </packing>
                         </child>
                         <child>
@@ -165,7 +165,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">4</property>
+                            <property name="top_attach">5</property>
                           </packing>
                         </child>
                         <child>
@@ -221,6 +221,20 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="nopopulate_check">
+                            <property name="label" translatable="yes">Include "do not populate" components</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/src/imp/pnp_export_window.cpp
+++ b/src/imp/pnp_export_window.cpp
@@ -50,6 +50,7 @@ PnPExportWindow::PnPExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
     GET_WIDGET(done_label);
     GET_WIDGET(done_revealer);
     GET_WIDGET(mode_combo);
+    GET_WIDGET(nopopulate_check);
     GET_WIDGET(filename_merged_entry);
     GET_WIDGET(filename_top_entry);
     GET_WIDGET(filename_bottom_entry);
@@ -73,6 +74,13 @@ PnPExportWindow::PnPExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
         s_signal_changed.emit();
     });
     update_filename_visibility();
+
+    nopopulate_check->set_active(settings.include_nopopulate);
+    nopopulate_check->signal_toggled().connect([this] {
+        settings.include_nopopulate = nopopulate_check->get_active();
+        s_signal_changed.emit();
+        update_preview();
+    });
 
     {
         Gtk::Box *column_chooser_box;

--- a/src/imp/pnp_export_window.hpp
+++ b/src/imp/pnp_export_window.hpp
@@ -41,6 +41,7 @@ private:
     Gtk::Button *directory_button = nullptr;
 
     Gtk::ComboBoxText *mode_combo = nullptr;
+    Gtk::CheckButton *nopopulate_check = nullptr;
     Gtk::Label *filename_merged_label = nullptr;
     Gtk::Label *filename_top_label = nullptr;
     Gtk::Label *filename_bottom_label = nullptr;

--- a/src/pool-prj-mgr/preferences_window_canvas.cpp
+++ b/src/pool-prj-mgr/preferences_window_canvas.cpp
@@ -34,6 +34,7 @@ static const std::map<ColorP, std::string> color_names = {
         {ColorP::PIN, "Pin"},
         {ColorP::PIN_HIDDEN, "Hidden Pin"},
         {ColorP::DIFFPAIR, "Diff. pair"},
+        {ColorP::NOPOPULATE_X, "Do not pop. X-out"},
         {ColorP::BACKGROUND, "Background"},
         {ColorP::GRID, "Grid"},
         {ColorP::CURSOR_NORMAL, "Cursor"},
@@ -51,8 +52,9 @@ static const std::map<ColorP, std::string> color_names = {
         {ColorP::SHADOW, "Highlight shadow"},
 };
 
-static const std::set<ColorP> colors_non_layer = {ColorP::NET, ColorP::BUS,        ColorP::FRAME,
-                                                  ColorP::PIN, ColorP::PIN_HIDDEN, ColorP::DIFFPAIR};
+static const std::set<ColorP> colors_non_layer = {ColorP::NET,         ColorP::BUS,        ColorP::FRAME,
+                                                  ColorP::PIN,         ColorP::PIN_HIDDEN, ColorP::DIFFPAIR,
+                                                  ColorP::NOPOPULATE_X};
 
 static const std::set<ColorP> colors_layer = {ColorP::FRAG_ORPHAN, ColorP::AIRWIRE_ROUTER, ColorP::TEXT_OVERLAY,
                                               ColorP::HOLE,        ColorP::DIMENSION,      ColorP::AIRWIRE,

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -90,6 +90,7 @@ static const LutEnumStr<ColorP> colorp_lut = {
         COLORP_LUT_ITEM(SEARCH_CURRENT),
         COLORP_LUT_ITEM(SHADOW),
         COLORP_LUT_ITEM(CONNECTION_LINE),
+        COLORP_LUT_ITEM(NOPOPULATE_X),
 };
 
 json CanvasPreferences::serialize() const


### PR DESCRIPTION
Only in the schematic editor for now;  marks an entire component (with
all its symbols) as DNP.  Drawn grayed out with an X over it (calculated
from the bounding box, occasionally looks a bit weird but eh.)

TBD/Future:
- ~add BOM export option to exclude DNP parts~ done
- visualize in board editor & assembly export

screenshot for posterity:
https://aurora.nox.tf/tmp/horizon_dnp.png