### PR TITLE
fix compiler error on missing std:string

### DIFF
--- a/src/export_pdf/export_pdf.hpp
+++ b/src/export_pdf/export_pdf.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <functional>
+#include <string>
 
 namespace horizon {
 void export_pdf(const class Schematic &sch, const class PDFExportSettings &settings,


### PR DESCRIPTION
GCC-10 (master) found this one

```
$ gcc --version | head -n 1
gcc (GCC) 10.0.1 20200328 (experimental)
```
```
build/obj/src/export_pdf/export_pdf.o
In file included from src/export_pdf/export_pdf.cpp:1:
src/export_pdf/export_pdf.hpp:6:41: error: ‘string’ is not a member of ‘std’
    6 |                 std::function<void(std::string, double)> cb = nullptr);
      |                                         ^~~~~~
src/export_pdf/export_pdf.hpp:3:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
```