### PR TITLE
footprint generator: add courtyard parameter class to polygon

### DIFF
--- a/src/imp/footprint_generator/footag/display.cpp
+++ b/src/imp/footprint_generator/footag/display.cpp
@@ -400,6 +400,7 @@ void FootagDisplay::calc(Package *pkg, const struct footag_spec *s)
         auto uu = UUID::random();
         auto &poly = pkg->polygons.emplace(uu, uu).first->second;
         make_rlimit_rect(poly, &s->courtyard, BoardLayers::TOP_COURTYARD);
+        poly.parameter_class = "courtyard";
     }
 }
 


### PR DESCRIPTION
Previously part of https://github.com/horizon-eda/horizon/pull/367, now only the courtyard parameter is changed in IPC generator