### PR TITLE
Redraw color selector when loading color scheme.

### DIFF
--- a/src/pool-prj-mgr/preferences_window_canvas.cpp
+++ b/src/pool-prj-mgr/preferences_window_canvas.cpp
@@ -70,7 +70,6 @@ public:
 protected:
     virtual std::string get_color_name() = 0;
     Gtk::DrawingArea *colorbox = nullptr;
-    void update_color(const Color &c);
 };
 
 ColorEditor::ColorEditor() : Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 5)

--- a/src/pool-prj-mgr/preferences_window_canvas.cpp
+++ b/src/pool-prj-mgr/preferences_window_canvas.cpp
@@ -466,6 +466,7 @@ void CanvasPreferencesEditor::handle_default()
     preferences->signal_changed().emit();
     update_color_chooser();
     queue_draw();
+    canvas_colors_fb->queue_draw();
 }
 
 void CanvasPreferencesEditor::load_colors(const json &j)
@@ -474,6 +475,7 @@ void CanvasPreferencesEditor::load_colors(const json &j)
     preferences->signal_changed().emit();
     update_color_chooser();
     queue_draw();
+    canvas_colors_fb->queue_draw();
 }
 
 void CanvasPreferencesEditor::update_color_chooser()


### PR DESCRIPTION
Previously, when loading a color scheme or restoring to default, the
list of colors would keep their previous values until a redraw was
forced by selecting another color or modifying the currently selected
color.