### PR TITLE
Sheet References

### DIFF
--- a/src/imp/imp_schematic.cpp
+++ b/src/imp/imp_schematic.cpp
@@ -521,8 +521,9 @@ void ImpSchematic::construct()
                     if (sch->sheets.count(uuid)) {
                         sheet_box->select_sheet(uuid);
                     }
+                    return true;
                 }
-                return true;
+                return false;
             },
             false);
 

--- a/src/imp/imp_schematic.cpp
+++ b/src/imp/imp_schematic.cpp
@@ -516,7 +516,6 @@ void ImpSchematic::construct()
             [this](const std::string &url) {
                 if (url.find("s:") == 0) {
                     std::string sheet = url.substr(2);
-                    std::cout << "sheet " << sheet << std::endl;
                     auto uuid = UUID(sheet);
                     auto sch = core_schematic.get_schematic();
                     if (sch->sheets.count(uuid)) {
@@ -600,11 +599,8 @@ std::string ImpSchematic::get_hud_text(std::set<SelectableRef> &sel)
     if (sel_count_type(sel, ObjectType::TEXT) == 1) {
         const auto text = core->get_text(sel_find_one(sel, ObjectType::TEXT).uuid);
         const auto txt = Glib::ustring(text->text);
-        auto regex = Glib::Regex::create(
-                R"(\$sheetref_([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}))",
-                Glib::RegexCompileFlags::REGEX_CASELESS);
         Glib::MatchInfo ma;
-        if (regex->match(txt, ma)) {
+        if (core_schematic.get_schematic()->get_sheetref_regex()->match(txt, ma)) {
             s += "\n\n<b>Text with sheet references</b>\n";
             do {
                 auto uuid = ma.fetch(1);
@@ -613,8 +609,9 @@ std::string ImpSchematic::get_hud_text(std::set<SelectableRef> &sel)
                     s += make_link_markup(url, core_schematic.get_schematic()->sheets.at(UUID(uuid)).name);
                 }
                 else {
-                    s += make_link_markup(url, "Unknown Sheet");
+                    s += "Unknown Sheet";
                 }
+                s += "\n";
             } while (ma.next());
             sel_erase_type(sel, ObjectType::TEXT);
         }

--- a/src/imp/main_window.hpp
+++ b/src/imp/main_window.hpp
@@ -33,6 +33,12 @@ public:
     Gtk::Box *search_types_box = nullptr;
     Gtk::Label *selection_mode_label = nullptr;
 
+    Glib::SignalProxy<bool, const Glib::ustring &> signal_activate_hud_link()
+    {
+        return hud_label->signal_activate_link();
+    }
+
+
     void tool_bar_set_visible(bool v);
     void tool_bar_set_tool_name(const std::string &s);
     void tool_bar_set_tool_tip(const std::string &s);

--- a/src/schematic/schematic.cpp
+++ b/src/schematic/schematic.cpp
@@ -6,7 +6,6 @@
 #include "nlohmann/json.hpp"
 #include "util/util.hpp"
 #include "logger/logger.hpp"
-#include <glibmm/regex.h>
 
 namespace horizon {
 
@@ -798,17 +797,14 @@ void Schematic::expand(bool careful)
     }
 
     if (!careful) {
-        auto regex = Glib::Regex::create(
-                R"(\$sheetref_([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}))",
-                Glib::RegexCompileFlags::REGEX_CASELESS | Glib::RegexCompileFlags::REGEX_OPTIMIZE);
         for (auto &it_sheet : sheets) {
             Sheet &sheet = it_sheet.second;
             for (auto &it_text : sheet.texts) {
                 auto &text = it_text.second;
-                auto txt = text.text;
+                Glib::ustring txt = text.text;
                 Glib::MatchInfo ma;
                 int start, end;
-                while (regex->match(txt, ma) && ma.fetch_pos(0, start, end)) {
+                while (get_sheetref_regex()->match(txt, ma) && ma.fetch_pos(0, start, end)) {
                     auto ref_uuid = UUID(ma.fetch(1));
                     if (sheets.count(ref_uuid)) {
                         std::stringstream ss;
@@ -984,6 +980,14 @@ void Schematic::swap_gates(const UUID &comp_uu, const UUID &g1_uu, const UUID &g
             }
         }
     }
+}
+
+Glib::RefPtr<Glib::Regex> Schematic::get_sheetref_regex()
+{
+    static auto regex =
+            Glib::Regex::create(R"(\$sheetref:([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}))",
+                                Glib::RegexCompileFlags::REGEX_CASELESS | Glib::RegexCompileFlags::REGEX_OPTIMIZE);
+    return regex;
 }
 
 Schematic::Schematic(const Schematic &sch)

--- a/src/schematic/schematic.hpp
+++ b/src/schematic/schematic.hpp
@@ -6,6 +6,7 @@
 #include "sheet.hpp"
 #include "schematic_rules.hpp"
 #include "common/pdf_export_settings.hpp"
+#include <glibmm/regex.h>
 #include <vector>
 #include <map>
 #include <fstream>
@@ -28,7 +29,6 @@ class Schematic {
 private:
     Schematic(const UUID &uu, const json &, Block &block, class Pool &pool);
     unsigned int update_nets();
-
 
 public:
     static Schematic new_from_file(const std::string &filename, Block &block, Pool &pool);
@@ -82,6 +82,8 @@ public:
     void swap_gates(const UUID &comp, const UUID &g1, const UUID &g2);
 
     std::map<UUIDPath<2>, std::string> get_unplaced_gates() const;
+
+    static Glib::RefPtr<Glib::Regex> get_sheetref_regex();
 
     UUID uuid;
     Block *block;

--- a/src/widgets/sheet_box.cpp
+++ b/src/widgets/sheet_box.cpp
@@ -51,6 +51,32 @@ SheetBox::SheetBox(CoreSchematic *c) : Gtk::Box(Gtk::Orientation::ORIENTATION_VE
     view->get_selection()->signal_changed().connect(sigc::mem_fun(*this, &SheetBox::selection_changed));
     pack_start(*sc, true, true, 0);
 
+    {
+        auto item = Gtk::manage(new Gtk::MenuItem("Copy UUID"));
+        item->signal_activate().connect([this] {
+            auto it = view->get_selection()->get_selected();
+            if (it) {
+                Gtk::TreeModel::Row row = *it;
+                horizon::UUID uuid = row[list_columns.uuid];
+                std::string str = uuid;
+                auto clip = Gtk::Clipboard::get();
+                clip->set_text(str);
+            }
+        });
+        item->show();
+        menu.append(*item);
+    }
+
+    view->signal_button_press_event().connect_notify([this](GdkEventButton *ev) {
+        Gtk::TreeModel::Path path;
+        if (ev->button == 3) {
+#if GTK_CHECK_VERSION(3, 22, 0)
+            menu.popup_at_pointer((GdkEvent *)ev);
+#else
+            menu.popup(ev->button, gtk_get_current_event_time());
+#endif
+        }
+    });
 
     auto tb = Gtk::manage(new Gtk::Toolbar());
     tb->get_style_context()->add_class("inline-toolbar");

--- a/src/widgets/sheet_box.hpp
+++ b/src/widgets/sheet_box.hpp
@@ -53,6 +53,8 @@ private:
     Gtk::TreeView *view;
     Glib::RefPtr<Gtk::ListStore> store;
 
+    Gtk::Menu menu;
+
     type_signal_select_sheet s_signal_select_sheet;
     type_signal_add_sheet s_signal_add_sheet;
     type_signal_remove_sheet s_signal_remove_sheet;


### PR DESCRIPTION
This PR enables sheet references in the schematic.
My use case for this are block diagrams. There it is very helpful to reference another page. Since these references are dynamically generated using the UUID of the respective sheet, they are automatically updated whenever pages are put in a new order.
Additionally, sheet references are shown in the HUD.