### PR TITLE
Fix copying frame of current sheet to new sheet

### DIFF
--- a/src/core/core_schematic.cpp
+++ b/src/core/core_schematic.cpp
@@ -543,7 +543,7 @@ void CoreSchematic::add_sheet()
     auto *sheet = &sch.sheets.emplace(uu, uu).first->second;
     sheet->index = sheet_max->second.index + 1;
     sheet->name = "sheet " + std::to_string(sheet->index);
-    sheet->frame = sch.sheets.at(sheet_uuid).frame;
+    sheet->pool_frame = sch.sheets.at(sheet_uuid).pool_frame;
     rebuild();
 }
 


### PR DESCRIPTION
Currently, when creating a new sheet, instead of copying the frame reference of the current frame, the frame contents are copied. This results in frames with the contents of the one on the previous sheet. Additionally, users have to manually select the frame for every sheet for proper operation.

By copying pool_frame instead of frame, this can be fixed.