### PR TITLE
Annotations: Fix gap filling for multi page components

### DIFF
--- a/src/schematic/schematic.cpp
+++ b/src/schematic/schematic.cpp
@@ -883,7 +883,7 @@ void Schematic::annotate()
                     if (annotation.fill_gaps && v.size() >= 2) {
                         bool hole = false;
                         for (auto it = v.begin(); it < v.end() - 1; it++) {
-                            if (*(it + 1) != (*it) + 1) {
+                            if (*it > sheet_offset && *(it + 1) != (*it) + 1) {
                                 n = (*it) + 1;
                                 hole = true;
                                 break;


### PR DESCRIPTION
This fixes behavior of the annotation tool in the following condition:
- Mode "Sheet increment 100" or "Sheet increment 1000"
- "Fill gaps" enabled
- Gates of at least one component spread across two or more pages
- Gates of at least two more components on any but the first page containing gates of component mentioned above

Current behavior in these cases is that e.g. all components on the second page will be assigned the number 201 if a gate from a component that is on page 1 is also on page 2.