### PR TITLE
Disable outline creation in pdf export for podofo version 0.9.5

### DIFF
--- a/src/export_pdf/export_pdf.cpp
+++ b/src/export_pdf/export_pdf.cpp
@@ -40,10 +40,12 @@ void export_pdf(const class Schematic &sch, const class PDFExportSettings &setti
 
     auto font = document.CreateFont("Helvetica");
 
+#if PODOFO_VERSION_MAJOR != 0 || PODOFO_VERSION_MINOR != 9 || PODOFO_VERSION_PATCH != 5
     auto outlines = document.GetOutlines();
     auto proot = outlines->CreateRoot(title);
 
     bool first_outline_item = true;
+#endif
 
     CanvasPDF ca(&painter, font, settings);
     ca.use_layer_colors = false;
@@ -62,11 +64,13 @@ void export_pdf(const class Schematic &sch, const class PDFExportSettings &setti
         painter.FinishPage();
 
 
+#if PODOFO_VERSION_MAJOR != 0 || PODOFO_VERSION_MINOR != 9 || PODOFO_VERSION_PATCH != 5
         if (first_outline_item)
             proot->CreateChild(sheet->name, PoDoFo::PdfDestination(page));
         else
             proot->Last()->CreateNext(sheet->name, PoDoFo::PdfDestination(page));
         first_outline_item = false;
+#endif
     }
     document.Close();
 }


### PR DESCRIPTION
There is a bug that existed in podofo from revision 1775 to 1826. Because of this, only version 0.9.5 should be affected. With this bug it is not possible to create a PdfOutlineItem.

Since e.g. Ubuntu 18.04 LTS ships with this version podofo, it is not possible to export PDFs from horizon on Ubuntu 18.04 with libpodofo from the official repositories. The best remedy for this is to skip creating an outline when linked against podofo 0.9.5 since all the other steps run fine.