### PR TITLE
Show pin name on pad in board editor

### DIFF
--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -816,6 +816,8 @@ void Board::expand_packages()
                 }
                 else {
                     it_pad.second.net = nullptr;
+                }
+                if (it.second.pin_name_on_pad || it_pad.second.net == nullptr) {
                     it_pad.second.secondary_text = "("
                                                    + it.second.component->part->entity->gates.at(pin_path.at(0))
                                                              .unit->pins.at(pin_path.at(1))
@@ -825,7 +827,7 @@ void Board::expand_packages()
             }
             else {
                 it_pad.second.net = nullptr;
-                it_pad.second.secondary_text = "NC";
+                it_pad.second.secondary_text = "(unmapped)";
                 it_pad.second.is_nc = true;
             }
         }

--- a/src/board/board_package.hpp
+++ b/src/board/board_package.hpp
@@ -34,6 +34,7 @@ public:
     bool omit_silkscreen = false;
     bool fixed = false;
     bool omit_outline = false;
+    bool pin_name_on_pad = false;
     std::vector<uuid_ptr<Text>> texts;
 
     std::string replace_text(const std::string &t, bool *replaced = nullptr) const;

--- a/src/common/object_descr.cpp
+++ b/src/common/object_descr.cpp
@@ -249,6 +249,7 @@ const std::map<ObjectType, ObjectDescription> object_descriptions = {
                   {ObjectProperty::ID::OMIT_SILKSCREEN, {ObjectProperty::Type::BOOL, "Omit Silkscreen", 7}},
                   {ObjectProperty::ID::OMIT_OUTLINE, {ObjectProperty::Type::BOOL, "Omit outline", 8}},
                   {ObjectProperty::ID::FIXED, {ObjectProperty::Type::BOOL, "Fix", 9}},
+                  {ObjectProperty::ID::PIN_NAME_ON_PAD, {ObjectProperty::Type::BOOL, "Pin names on pads", 10}},
           }}},
         {ObjectType::TRACK,
          {"Track",

--- a/src/common/object_descr.hpp
+++ b/src/common/object_descr.hpp
@@ -74,6 +74,7 @@ public:
         OMIT_SILKSCREEN,
         FIXED,
         NOPOPULATE,
+        PIN_NAME_ON_PAD,
         OMIT_OUTLINE
     };
     ObjectProperty(Type t, const std::string &l, int o = 0, const std::vector<std::pair<int, std::string>> &its = {})

--- a/src/core/core_board.cpp
+++ b/src/core/core_board.cpp
@@ -117,6 +117,10 @@ bool CoreBoard::get_property(ObjectType type, const UUID &uu, ObjectProperty::ID
             dynamic_cast<PropertyValueBool &>(value).value = pkg->omit_outline;
             return true;
 
+        case ObjectProperty::ID::PIN_NAME_ON_PAD:
+            dynamic_cast<PropertyValueBool &>(value).value = pkg->pin_name_on_pad;
+            return true;
+
         default:
             return false;
         }
@@ -322,6 +326,10 @@ bool CoreBoard::set_property(ObjectType type, const UUID &uu, ObjectProperty::ID
 
         case ObjectProperty::ID::OMIT_OUTLINE:
             pkg->omit_outline = dynamic_cast<const PropertyValueBool &>(value).value;
+            break;
+
+        case ObjectProperty::ID::PIN_NAME_ON_PAD:
+            pkg->pin_name_on_pad = dynamic_cast<const PropertyValueBool &>(value).value;
             break;
 
         default:


### PR DESCRIPTION
This commit adds a new toggle switch when a package is selected in the
board editor.

Setting this toggle in the "on" position forces pin name to be
displayed on every pad. Setting this toggle to "off" gives the previous
behavior of showing the assigned net name if available.

Motivation:
1. It is useful to be able to distinguish between proper power pads and
pads which have been assigned to a power net. For example configuration pins.

2. Adds a visual cue when doing fan-out of I/O pads which do not yet
have a net name assigned.

The solution is simple and has the following limitations:
- The switch enters the *off* position when doing history undo.
- Takes vertical space from the right hand side panel.