### PR TITLE
Add distraction free mode

### DIFF
--- a/src/imp/action.hpp
+++ b/src/imp/action.hpp
@@ -89,6 +89,7 @@ enum class ActionID {
     GEN_FAB_OUTPUT,
     FOOTPRINT_GENERATOR,
     SET_GRID_ORIGIN,
+    DISTRACTION_FREE,
 };
 
 using ActionToolID = std::pair<ActionID, ToolID>;

--- a/src/imp/action_catalog.cpp
+++ b/src/imp/action_catalog.cpp
@@ -4,6 +4,10 @@
 
 namespace horizon {
 const std::map<ActionToolID, ActionCatalogItem> action_catalog = {
+        {{ActionID::DISTRACTION_FREE, ToolID::NONE},
+         {"Toggle distraction free mode", ActionGroup::UNKNOWN, ActionCatalogItem::AVAILABLE_EVERYWHERE,
+          ActionCatalogItem::FLAGS_DEFAULT}},
+
         {{ActionID::SELECTION_FILTER, ToolID::NONE},
          {"Selection filter", ActionGroup::UNKNOWN, ActionCatalogItem::AVAILABLE_EVERYWHERE,
           ActionCatalogItem::FLAGS_DEFAULT}},
@@ -864,6 +868,7 @@ const std::vector<std::pair<ActionGroup, std::string>> action_group_catalog = {
 const LutEnumStr<ActionID> action_lut = {
         ACTION_LUT_ITEM(TOOL),
         ACTION_LUT_ITEM(SELECTION_FILTER),
+        ACTION_LUT_ITEM(DISTRACTION_FREE),
         ACTION_LUT_ITEM(SAVE),
         ACTION_LUT_ITEM(VIEW_3D),
         ACTION_LUT_ITEM(UNDO),

--- a/src/imp/imp.hpp
+++ b/src/imp/imp.hpp
@@ -103,6 +103,7 @@ protected:
     bool sockets_connected = false;
     int mgr_pid = -1;
     bool no_update = false;
+    bool distraction_free = false;
 
     virtual void canvas_update() = 0;
     virtual void expand_selection_for_property_panel(std::set<SelectableRef> &sel_extra,
@@ -279,5 +280,6 @@ private:
     std::list<class ActionButtonBase *> action_buttons;
 
     Glib::RefPtr<Gio::SimpleAction> bottom_view_action;
+    Glib::RefPtr<Gio::SimpleAction> distraction_free_action;
 };
 } // namespace horizon


### PR DESCRIPTION
Currently this just hides the left panel and the property panel.

Open questions:
- should more things be hidden? I think the way it currently works is fine.
- should there be some kind of indication that one is in distraction free mode? I don't think its necessary, but could help people that enter it on accident.