### PR TITLE
Makefile: use CXXFLAGS and LDFLAGS from environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,11 +652,11 @@ ifneq ($(OS),Windows_NT)
 endif
 LIBS_ALL = $(LIBS_COMMON) gtkmm-3.0 epoxy cairomm-pdf-1.0 librsvg-2.0 libzmq libgit2 libcurl glm
 
-OPTIMIZE=-fdata-sections -ffunction-sections
-DEBUGFLAGS   =-g3
-CXXFLAGS  =$(DEBUGFLAGS) $(DEFINES) $(OPTIMIZE) $(shell $(PKG_CONFIG) --cflags $(LIBS_ALL)) -MP -MMD -pthread -Wall -Wshadow -std=c++17 -O3
+OPTIMIZE = -fdata-sections -ffunction-sections
+DEBUGFLAGS = -g3
+CXXFLAGS += $(DEBUGFLAGS) $(DEFINES) $(OPTIMIZE) $(shell $(PKG_CONFIG) --cflags $(LIBS_ALL)) -MP -MMD -pthread -Wall -Wshadow -std=c++17 -O3
 CFLAGS = $(filter-out -std=%,$(CXXFLAGS)) -std=c99
-LDFLAGS = -lm -lpthread
+LDFLAGS += -lm -lpthread
 GLIB_COMPILE_RESOURCES = $(shell $(PKG_CONFIG) --variable=glib_compile_resources gio-2.0)
 
 ifeq ($(DEBUG),1)


### PR DESCRIPTION
If the initial CXXFLAGS and LDFLAGS definitions use `+=` instead of `=`,
they will also contain the contents of the environment variables with
the same name. This makes it easy for distro packagers to include their
package-wide compilation flags.