### PR TITLE
Allow hiding of DNP components in 3D view

### DIFF
--- a/src/canvas3d/canvas3d_base.cpp
+++ b/src/canvas3d/canvas3d_base.cpp
@@ -294,11 +294,11 @@ void Canvas3DBase::prepare_packages()
         return;
     package_transform_idxs.clear();
     package_transforms.clear();
-    std::map<std::string, std::set<const BoardPackage *>> pkg_map;
+    std::map<std::pair<std::string, bool>, std::set<const BoardPackage *>> pkg_map;
     for (const auto &it : brd->packages) {
         auto model = it.second.package.get_model(it.second.model);
         if (model)
-            pkg_map[model->filename].insert(&it.second);
+            pkg_map[{model->filename, it.second.component->nopopulate}].insert(&it.second);
     }
 
     for (const auto &it_pkg : pkg_map) {

--- a/src/canvas3d/canvas3d_base.hpp
+++ b/src/canvas3d/canvas3d_base.hpp
@@ -28,6 +28,7 @@ public:
     bool show_silkscreen = true;
     bool show_substrate = true;
     bool show_models = true;
+    bool show_dnp_models = false;
     bool show_solder_paste = true;
     bool use_layer_colors = false;
     Color solder_mask_color = {0, .5, 0};
@@ -140,9 +141,9 @@ private:
     std::vector<ModelTransform> package_transforms; // position and rotation of
                                                     // all board packages,
                                                     // grouped by package
-    std::map<std::string, std::pair<size_t, size_t>>
-            package_transform_idxs; // key: model filename: value: first: offset
-                                    // in package_transforms second: no of items
+    std::map<std::pair<std::string, bool>, std::pair<size_t, size_t>>
+            package_transform_idxs; // key: first: model filename second: nopopulate
+                                    // value: first: offset in package_transforms second: no of items
 
     float get_magic_number() const;
 };

--- a/src/canvas3d/face.cpp
+++ b/src/canvas3d/face.cpp
@@ -153,8 +153,15 @@ void FaceRenderer::render()
         glUniform1f(highlight_intensity_loc, ca.highlight_intensity);
 
         for (const auto &it : ca.models) {
-            if (ca.package_transform_idxs.count(it.first)) {
-                auto idxs = ca.package_transform_idxs.at(it.first);
+            std::pair<std::string, bool> populate = {it.first, false};
+            std::pair<std::string, bool> nopopulate = {it.first, true};
+            if (ca.package_transform_idxs.count(populate)) {
+                auto idxs = ca.package_transform_idxs.at(populate);
+                glDrawElementsInstancedBaseInstance(GL_TRIANGLES, it.second.second, GL_UNSIGNED_INT,
+                                                    (void *)(it.second.first * sizeof(int)), idxs.second, idxs.first);
+            }
+            if (ca.show_dnp_models && ca.package_transform_idxs.count(nopopulate)) {
+                auto idxs = ca.package_transform_idxs.at(nopopulate);
                 glDrawElementsInstancedBaseInstance(GL_TRIANGLES, it.second.second, GL_UNSIGNED_INT,
                                                     (void *)(it.second.first * sizeof(int)), idxs.second, idxs.first);
             }

--- a/src/imp/3d_view.cpp
+++ b/src/imp/3d_view.cpp
@@ -156,10 +156,17 @@ View3DWindow::View3DWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Buil
         canvas->queue_draw();
     });
 
-    Gtk::Switch *models_switch;
-    x->get_widget("models_switch", models_switch);
-    models_switch->property_active().signal_changed().connect([this, models_switch] {
-        canvas->show_models = models_switch->get_active();
+    Gtk::RadioButton *models_none_rb;
+    x->get_widget("models_none_rb", models_none_rb);
+    models_none_rb->property_active().signal_changed().connect([this, models_none_rb] {
+        canvas->show_models = !models_none_rb->get_active();
+        canvas->queue_draw();
+    });
+
+    Gtk::RadioButton *models_placed_rb;
+    x->get_widget("models_placed_rb", models_placed_rb);
+    models_placed_rb->property_active().signal_changed().connect([this, models_placed_rb] {
+        canvas->show_dnp_models = !models_placed_rb->get_active();
         canvas->queue_draw();
     });
 

--- a/src/imp/3d_view.ui
+++ b/src/imp/3d_view.ui
@@ -282,12 +282,59 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="models_switch">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="active">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkRadioButton" id="models_none_rb">
+                                <property name="label" translatable="yes">None</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">False</property>
+                                <property name="group">models_placed_rb</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkRadioButton" id="models_placed_rb">
+                                <property name="label" translatable="yes">Placed</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkRadioButton" id="models_all_rb">
+                                <property name="label" translatable="yes">All</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="active">True</property>
+                                <property name="draw_indicator">False</property>
+                                <property name="group">models_placed_rb</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <style>
+                              <class name="linked"/>
+                            </style>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>


### PR DESCRIPTION
This adds an extra switch to 3D view settings that can be used to show or hide DNP components. Right now, it is called "DNP 3D Models" and off by defaults. Not very happy with the name, but I couldn't think of anything shorter that brings the point across...