### PR TITLE
Makefile: remove gold linker, fix indentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,19 +669,21 @@ endif
 
 
 ifeq ($(OS),Windows_NT)
-    LDFLAGS += -lrpcrt4
-    DEFINES += -DWIN32_UUID
-    LDFLAGS_GUI = -Wl,-subsystem,windows
+	LDFLAGS += -lrpcrt4
+	DEFINES += -DWIN32_UUID
+	LDFLAGS_GUI = -Wl,-subsystem,windows
 else
-    UNAME := $(shell uname)
-    ifeq ($(UNAME), FreeBSD)
-        CXXFLAGS += -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
-    endif
-    ifeq ($(UNAME), Darwin)
-        # do nothing on mac os
-    else
-        LDFLAGS += -fuse-ld=gold
-    endif
+	UNAME := $(shell uname)
+	ifeq ($(UNAME), FreeBSD)
+		CXXFLAGS += -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
+	endif
+	ifeq ($(UNAME), Darwin)
+		# do nothing on mac os
+	else
+		# allow ld.gold to be overriden by command line
+		GOLD = -fuse-ld=gold
+		LDFLAGS += $(GOLD)
+	endif
 endif
 
 SRC_SHARED = $(SRC_COMMON) \


### PR DESCRIPTION
Gold linker brings little benefit, isn't available or fully compliant
for some architectures, and can have issues with libraries located
outside /usr/lib.

Rust tried enabling it, but had to revert: https://github.com/rust-lang/rust/pull/30913

When packaging Horizon for Void Linux, I had to remove  `-fuse-ld=gold` from the Makefile, since it isn't available for our cross compilation setup.

It was enabled some years ago for no reason that I could find.

This way, if someone wants it, it can still be passed on the environment.