### PR TITLE
Add holes rendering to PDF export

### DIFF
--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -435,8 +435,9 @@ void Board::update_pdf_export_settings(PDFExportSettings &settings)
 {
     auto layers_from_board = get_layers();
     // remove layers not on board
-    map_erase_if(settings.layers,
-                 [&layers_from_board](const auto &it) { return layers_from_board.count(it.first) == 0; });
+    map_erase_if(settings.layers, [&layers_from_board](const auto &it) {
+        return it.first != PDFExportSettings::HOLES_LAYER && layers_from_board.count(it.first) == 0;
+    });
 
     // add new layers
     auto add_layer = [&settings](int l, bool enable = true) {
@@ -444,6 +445,9 @@ void Board::update_pdf_export_settings(PDFExportSettings &settings)
                 std::piecewise_construct, std::forward_as_tuple(l),
                 std::forward_as_tuple(l, Color(0, 0, 0), PDFExportSettings::Layer::Mode::OUTLINE, enable));
     };
+
+    // add holes layer
+    add_layer(PDFExportSettings::HOLES_LAYER, false);
 
     add_layer(BoardLayers::OUTLINE_NOTES);
     add_layer(BoardLayers::L_OUTLINE);

--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -32,7 +32,7 @@ BoardColors::BoardColors() : solder_mask({0, .5, 0}), substrate({.2, .15, 0})
 {
 }
 
-static const unsigned int app_version = 0;
+static const unsigned int app_version = 1;
 
 Board::Board(const UUID &uu, const json &j, Block &iblock, IPool &pool, ViaPadstackProvider &vpp)
     : uuid(uu), block(&iblock), name(j.at("name").get<std::string>()), version(app_version, j),

--- a/src/common/pdf_export_settings.cpp
+++ b/src/common/pdf_export_settings.cpp
@@ -33,7 +33,9 @@ PDFExportSettings::Layer::Layer(int l, const Color &c, Mode m, bool e) : layer(l
 
 PDFExportSettings::PDFExportSettings(const json &j)
     : output_filename(j.at("output_filename").get<std::string>()), min_line_width(j.at("min_line_width")),
-      reverse_layers(j.value("reverse_layers", false)), mirror(j.value("mirror", false))
+      reverse_layers(j.value("reverse_layers", false)), mirror(j.value("mirror", false)),
+      render_holes(j.value("render_holes", false)), set_holes_size(j.value("set_holes_size", false)),
+      holes_diameter(j.value("holes_diameter", 0))
 {
     if (j.count("layers")) {
         const json &o = j.at("layers");
@@ -65,6 +67,9 @@ json PDFExportSettings::serialize_board() const
     }
     j["reverse_layers"] = reverse_layers;
     j["mirror"] = mirror;
+    j["render_holes"] = render_holes;
+    j["set_holes_size"] = set_holes_size;
+    j["holes_diameter"] = holes_diameter;
     return j;
 }
 

--- a/src/common/pdf_export_settings.cpp
+++ b/src/common/pdf_export_settings.cpp
@@ -34,8 +34,7 @@ PDFExportSettings::Layer::Layer(int l, const Color &c, Mode m, bool e) : layer(l
 PDFExportSettings::PDFExportSettings(const json &j)
     : output_filename(j.at("output_filename").get<std::string>()), min_line_width(j.at("min_line_width")),
       reverse_layers(j.value("reverse_layers", false)), mirror(j.value("mirror", false)),
-      render_holes(j.value("render_holes", false)), set_holes_size(j.value("set_holes_size", false)),
-      holes_diameter(j.value("holes_diameter", 0))
+      set_holes_size(j.value("set_holes_size", false)), holes_diameter(j.value("holes_diameter", 0))
 {
     if (j.count("layers")) {
         const json &o = j.at("layers");
@@ -67,7 +66,6 @@ json PDFExportSettings::serialize_board() const
     }
     j["reverse_layers"] = reverse_layers;
     j["mirror"] = mirror;
-    j["render_holes"] = render_holes;
     j["set_holes_size"] = set_holes_size;
     j["holes_diameter"] = holes_diameter;
     return j;

--- a/src/common/pdf_export_settings.hpp
+++ b/src/common/pdf_export_settings.hpp
@@ -21,9 +21,10 @@ public:
     bool mirror = false;
     bool include_text = true;
 
-    bool render_holes = false;
     bool set_holes_size = false;
     uint64_t holes_diameter = 0;
+
+    enum { HOLES_LAYER = 1000 };
 
     class Layer {
     public:

--- a/src/common/pdf_export_settings.hpp
+++ b/src/common/pdf_export_settings.hpp
@@ -21,6 +21,10 @@ public:
     bool mirror = false;
     bool include_text = true;
 
+    bool render_holes = false;
+    bool set_holes_size = false;
+    uint64_t holes_diameter = 0;
+
     class Layer {
     public:
         Layer(int l, const json &j);

--- a/src/common/pdf_export_settings.hpp
+++ b/src/common/pdf_export_settings.hpp
@@ -24,7 +24,7 @@ public:
     bool set_holes_size = false;
     uint64_t holes_diameter = 0;
 
-    enum { HOLES_LAYER = 1000 };
+    enum { HOLES_LAYER = 10000 };
 
     class Layer {
     public:

--- a/src/export_pdf/canvas_pdf.hpp
+++ b/src/export_pdf/canvas_pdf.hpp
@@ -37,6 +37,7 @@ private:
     void img_draw_text(const Coordf &p, float size, const std::string &rtext, int angle, bool flip, TextOrigin origin,
                        int layer = 10000, uint64_t width = 0, TextData::Font font = TextData::Font::SIMPLEX,
                        bool center = false, bool mirror = false) override;
+    void img_hole(const Hole &hole) override;
     bool pdf_layer_visible(int l) const;
     Color get_pdf_layer_color(int layer) const;
 };

--- a/src/imp/pdf_export_window.cpp
+++ b/src/imp/pdf_export_window.cpp
@@ -41,7 +41,10 @@ PDFLayerEditor::PDFLayerEditor(BaseObjectType *cobject, const Glib::RefPtr<Gtk::
     x->get_widget("layer_color", layer_color);
     parent.sg_layer_name->add_widget(*layer_checkbutton);
 
-    layer_checkbutton->set_label(parent.core.get_layer_provider().get_layers().at(layer.layer).name);
+    auto name = layer.layer == PDFExportSettings::HOLES_LAYER
+                        ? "Holes"
+                        : parent.core.get_layer_provider().get_layers().at(layer.layer).name;
+    layer_checkbutton->set_label(name);
     bind_widget(layer_checkbutton, layer.enabled);
     layer_checkbutton->signal_toggled().connect([this] { s_signal_changed.emit(); });
     {
@@ -137,12 +140,6 @@ PDFExportWindow::PDFExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
             grid_attach_label_and_widget(grid, "Orientation", box, top);
         }
         {
-            auto box = make_boolean_ganged_switch(settings.render_holes, "Off", "On",
-                                                  [this](auto v) { s_signal_changed.emit(); });
-
-            grid_attach_label_and_widget(grid, "Render holes", box, top);
-        }
-        {
             auto box = make_boolean_ganged_switch(settings.set_holes_size, "Actual", "Specified",
                                                   [this](auto v) { s_signal_changed.emit(); });
 
@@ -150,7 +147,7 @@ PDFExportWindow::PDFExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
         }
         {
             auto sp = Gtk::manage(new SpinButtonDim);
-            sp->set_range(0, .1_mm);
+            sp->set_range(0, 10.0_mm);
             bind_widget(sp, settings.holes_diameter);
             sp->signal_value_changed().connect([this] { s_signal_changed.emit(); });
             grid_attach_label_and_widget(grid, "Holes diameter", sp, top);

--- a/src/imp/pdf_export_window.cpp
+++ b/src/imp/pdf_export_window.cpp
@@ -136,6 +136,25 @@ PDFExportWindow::PDFExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
 
             grid_attach_label_and_widget(grid, "Orientation", box, top);
         }
+        {
+            auto box = make_boolean_ganged_switch(settings.render_holes, "Off", "On",
+                                                  [this](auto v) { s_signal_changed.emit(); });
+
+            grid_attach_label_and_widget(grid, "Render holes", box, top);
+        }
+        {
+            auto box = make_boolean_ganged_switch(settings.set_holes_size, "Actual", "Specified",
+                                                  [this](auto v) { s_signal_changed.emit(); });
+
+            grid_attach_label_and_widget(grid, "Holes size", box, top);
+        }
+        {
+            auto sp = Gtk::manage(new SpinButtonDim);
+            sp->set_range(0, .1_mm);
+            bind_widget(sp, settings.holes_diameter);
+            sp->signal_value_changed().connect([this] { s_signal_changed.emit(); });
+            grid_attach_label_and_widget(grid, "Holes diameter", sp, top);
+        }
     }
 
     export_button->signal_clicked().connect(sigc::mem_fun(*this, &PDFExportWindow::generate));

--- a/src/imp/pdf_export_window.cpp
+++ b/src/imp/pdf_export_window.cpp
@@ -140,17 +140,21 @@ PDFExportWindow::PDFExportWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk
             grid_attach_label_and_widget(grid, "Orientation", box, top);
         }
         {
-            auto box = make_boolean_ganged_switch(settings.set_holes_size, "Actual", "Specified",
-                                                  [this](auto v) { s_signal_changed.emit(); });
+            auto box = make_boolean_ganged_switch(settings.set_holes_size, "Actual", "Specified", [this](auto v) {
+                s_signal_changed.emit();
+                holes_diameter_spin->set_sensitive(settings.set_holes_size);
+            });
 
             grid_attach_label_and_widget(grid, "Holes size", box, top);
         }
         {
             auto sp = Gtk::manage(new SpinButtonDim);
             sp->set_range(0, 10.0_mm);
+            sp->set_sensitive(settings.set_holes_size);
             bind_widget(sp, settings.holes_diameter);
             sp->signal_value_changed().connect([this] { s_signal_changed.emit(); });
             grid_attach_label_and_widget(grid, "Holes diameter", sp, top);
+            holes_diameter_spin = sp;
         }
     }
 

--- a/src/imp/pdf_export_window.hpp
+++ b/src/imp/pdf_export_window.hpp
@@ -36,6 +36,7 @@ private:
     Gtk::Entry *filename_entry = nullptr;
     Gtk::Button *filename_button = nullptr;
     class SpinButtonDim *min_line_width_sp = nullptr;
+    Gtk::SpinButton *holes_diameter_spin = nullptr;
     Gtk::Grid *grid = nullptr;
     Gtk::ListBox *layers_box;
     Glib::RefPtr<Gtk::SizeGroup> sg_layer_name;


### PR DESCRIPTION
KiCAD has "Drill marks" option which looks like so:
![kicad_drill_marks](https://user-images.githubusercontent.com/238571/97206630-cb891480-17da-11eb-83ef-d9e1919580e4.gif)

Because currently Horizon missing similar features, I trying to add it.
![image](https://user-images.githubusercontent.com/238571/97210066-e2ca0100-17de-11eb-8c0c-89b95e41c21e.png)
