### PR TITLE
circle support DXF import, curved airwire

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -958,6 +958,8 @@ $(OBJ_RES): $(OBJDIR)/%.res: %.rc
 	windres $< -O coff -o $@
 
 install: $(BUILDDIR)/horizon-imp $(BUILDDIR)/horizon-eda
+	strip $(BUILDDIR)/horizon-imp
+	strip $(BUILDDIR)/horizon-eda
 	mkdir -p $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m755 $(BUILDDIR)/horizon-imp $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m755 $(BUILDDIR)/horizon-eda $(DESTDIR)$(BINDIR)

--- a/src/canvas/annotation.cpp
+++ b/src/canvas/annotation.cpp
@@ -54,9 +54,28 @@ void CanvasAnnotation::draw_line(const Coordf &from, const Coordf &to, ColorP co
     ca->request_push();
 }
 
+void CanvasAnnotation::draw_circle(const Coordf &center, float radius0, ColorP color, uint64_t width)
+{
+    ca->draw_circle(center, radius0,color, layer,false, width);
+    ca->request_push();
+}
+
 void CanvasAnnotation::draw_arc(const Coordf &center, float radius0, float a0, float a1, ColorP color, uint64_t width)
 {
-    ca->draw_arc0(center, radius0, a0, a1, color, layer, width);
+    ca->draw_arc(center, radius0,a0,a1, color, layer,false, width);
+    ca->request_push();
+}
+
+
+void CanvasAnnotation::draw_curve(const Coordf &start, const Coordf &end, float divation, ColorP color, uint64_t width)
+{
+    ca->draw_curve(start,end,divation, color, layer,  false, width);
+    ca->request_push();
+}
+
+void CanvasAnnotation:: draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2,  ColorP color, uint64_t width)
+{
+    ca->draw_bezier2(p0,p1,p2, color, layer, false, width);
     ca->request_push();
 }
 

--- a/src/canvas/annotation.cpp
+++ b/src/canvas/annotation.cpp
@@ -56,26 +56,26 @@ void CanvasAnnotation::draw_line(const Coordf &from, const Coordf &to, ColorP co
 
 void CanvasAnnotation::draw_circle(const Coordf &center, float radius0, ColorP color, uint64_t width)
 {
-    ca->draw_circle(center, radius0,color, layer,false, width);
+    ca->draw_circle(center, radius0, color, layer, false, width);
     ca->request_push();
 }
 
 void CanvasAnnotation::draw_arc(const Coordf &center, float radius0, float a0, float a1, ColorP color, uint64_t width)
 {
-    ca->draw_arc(center, radius0,a0,a1, color, layer,false, width);
+    ca->draw_arc0(center, radius0, a0, a1, color, layer, width);
     ca->request_push();
 }
 
 
 void CanvasAnnotation::draw_curve(const Coordf &start, const Coordf &end, float divation, ColorP color, uint64_t width)
 {
-    ca->draw_curve(start,end,divation, color, layer,  false, width);
+    ca->draw_curve(start, end, divation, color, layer, false, width);
     ca->request_push();
 }
 
-void CanvasAnnotation:: draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2,  ColorP color, uint64_t width)
+void CanvasAnnotation::draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2, ColorP color, uint64_t width)
 {
-    ca->draw_bezier2(p0,p1,p2, color, layer, false, width);
+    ca->draw_bezier2(p0, p1, p2, color, layer, false, width);
     ca->request_push();
 }
 

--- a/src/canvas/annotation.hpp
+++ b/src/canvas/annotation.hpp
@@ -19,7 +19,7 @@ public:
     void draw_arc(const Coordf &center, float radius0, float a0, float a1, ColorP color, uint64_t width);
     void draw_circle(const Coordf &center, float radius0, ColorP color, uint64_t width);
     void draw_curve(const Coordf &start, const Coordf &end, float divation, ColorP color, uint64_t width);
-    void draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2,  ColorP color, uint64_t width);
+    void draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2, ColorP color, uint64_t width);
 
     bool on_top = true;
     bool use_highlight = false;

--- a/src/canvas/annotation.hpp
+++ b/src/canvas/annotation.hpp
@@ -17,6 +17,9 @@ public:
                    uint8_t color2 = 0);
     void draw_polygon(const std::deque<Coordf> &pts, ColorP color, uint64_t width);
     void draw_arc(const Coordf &center, float radius0, float a0, float a1, ColorP color, uint64_t width);
+    void draw_circle(const Coordf &center, float radius0, ColorP color, uint64_t width);
+    void draw_curve(const Coordf &start, const Coordf &end, float divation, ColorP color, uint64_t width);
+    void draw_bezier2(const Coordf &p0, const Coordf &p1, const Coordf &p2,  ColorP color, uint64_t width);
 
     bool on_top = true;
     bool use_highlight = false;

--- a/src/canvas/canvas.hpp
+++ b/src/canvas/canvas.hpp
@@ -146,6 +146,9 @@ protected:
                    bool tr = true, uint64_t width = 0);
     void draw_box(const Coord<float> &o, float size, ColorP color = ColorP::FROM_LAYER, int layer = 10000,
                   bool tr = true, uint64_t width = 0);
+    void draw_bezier2(const Coord<float> &start,const Coord<float> &mid,const Coord<float> &end, ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
+    void draw_curve(const Coord<float> &start,const Coord<float> &end,float diviation=0.1, ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
+    void draw_circle(const Coord<float> &center, float radius, ColorP color = ColorP::FROM_LAYER,int layer = 10000, bool tr = true, uint64_t width = 0);
     void draw_arc(const Coord<float> &center, float radius, float a0, float a1, ColorP color = ColorP::FROM_LAYER,
                   int layer = 10000, bool tr = true, uint64_t width = 0);
     std::pair<Coordf, Coordf> draw_arc2(const Coord<float> &center, float radius0, float a0, float a1, ColorP color,

--- a/src/canvas/canvas.hpp
+++ b/src/canvas/canvas.hpp
@@ -146,9 +146,12 @@ protected:
                    bool tr = true, uint64_t width = 0);
     void draw_box(const Coord<float> &o, float size, ColorP color = ColorP::FROM_LAYER, int layer = 10000,
                   bool tr = true, uint64_t width = 0);
-    void draw_bezier2(const Coord<float> &start,const Coord<float> &mid,const Coord<float> &end, ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
-    void draw_curve(const Coord<float> &start,const Coord<float> &end,float diviation=0.1, ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
-    void draw_circle(const Coord<float> &center, float radius, ColorP color = ColorP::FROM_LAYER,int layer = 10000, bool tr = true, uint64_t width = 0);
+    void draw_bezier2(const Coord<float> &start, const Coord<float> &mid, const Coord<float> &end,
+                      ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
+    void draw_curve(const Coord<float> &start, const Coord<float> &end, float diviation = 0.1,
+                    ColorP color = ColorP::FROM_LAYER, int layer = 10000, bool tr = true, uint64_t width = 0);
+    void draw_circle(const Coord<float> &center, float radius, ColorP color = ColorP::FROM_LAYER, int layer = 10000,
+                     bool tr = true, uint64_t width = 0);
     void draw_arc(const Coord<float> &center, float radius, float a0, float a1, ColorP color = ColorP::FROM_LAYER,
                   int layer = 10000, bool tr = true, uint64_t width = 0);
     std::pair<Coordf, Coordf> draw_arc2(const Coord<float> &center, float radius0, float a0, float a1, ColorP color,

--- a/src/canvas/draw.cpp
+++ b/src/canvas/draw.cpp
@@ -62,42 +62,48 @@ void Canvas::draw_box(const Coordf &p, float size, ColorP color, int layer, bool
     draw_line(p + Coordf(-size, -size), p + Coordf(-size, size), color, layer, tr, width);
 }
 
-void Canvas::draw_bezier2(const Coord<float> &start,const Coord<float> &mid,const Coord<float> &end, ColorP color, int layer , bool tr, uint64_t width){
-    const int segments = 10;
+void Canvas::draw_bezier2(const Coord<float> &start, const Coord<float> &mid, const Coord<float> &end, ColorP color,
+                          int layer, bool tr, uint64_t width)
+{
+    const int segments = 24;
     int count = segments;
-    if((start.x == mid.x && start.y == mid.y )|| (end.x == mid.x && end.y == mid.y )) { //if mid==start or mid==end, then it is just a line
-        draw_line(start,end, color, layer, tr, width);
+    if ((start.x == mid.x && start.y == mid.y)
+        || (end.x == mid.x && end.y == mid.y)) { // if mid==start or mid==end, then it is just a line
+        draw_line(start, end, color, layer, tr, width);
         return;
     }
-    float t=0;
-    Coord<float> lstart, lend , p0=start, p1;
+    float t = 0;
+    Coord<float> lstart, lend, p0 = start, p1;
 
     while (count--) {
-        t+=1.0/segments;
-        lstart= start+  (mid-start)*t;
-        lend =  mid+ (end-mid)*t;        
-        p1 = lstart + (lend-lstart)* t;
-        draw_line(p0,p1, color, layer, tr,width);
-        p0=p1;
+        t += 1.0 / segments;
+        lstart = start + (mid - start) * t;
+        lend = mid + (end - mid) * t;
+        p1 = lstart + (lend - lstart) * t;
+        draw_line(p0, p1, color, layer, tr, width);
+        p0 = p1;
     }
 }
 
-void Canvas::draw_curve(const Coord<float> &start,const Coord<float> &end,float diviation, ColorP color, int layer , bool tr, uint64_t width){
-    Coord<float> delta = end-start;
-    Coord<float> unit ;
-    unit.x=0; unit.y=1.0;
-    
-    Coord<float> mid= (start + end)*0.5;
-    delta*=diviation;
+void Canvas::draw_curve(const Coord<float> &start, const Coord<float> &end, float diviation, ColorP color, int layer,
+                        bool tr, uint64_t width)
+{
+    Coord<float> delta = end - start;
+    Coord<float> unit;
+    unit.x = 0;
+    unit.y = 1.0;
+
+    Coord<float> mid = (start + end) * 0.5;
+    delta *= diviation;
     float x = delta.x;
-    delta.x = - delta.y;
+    delta.x = -delta.y;
     delta.y = x;
-    mid +=delta;    
-    draw_bezier2(start, mid,end, color,layer,tr, width);
-    
+    mid += delta;
+    draw_bezier2(start, mid, end, color, layer, tr, width);
 }
 
-void Canvas::draw_circle(const Coord<float> &center, float radius, ColorP color , int layer , bool tr , uint64_t width ){
+void Canvas::draw_circle(const Coord<float> &center, float radius, ColorP color, int layer, bool tr, uint64_t width)
+{
     unsigned int segments = 64;
     float a0 = 0;
     float dphi = 2 * M_PI;

--- a/src/canvas/draw.cpp
+++ b/src/canvas/draw.cpp
@@ -62,6 +62,53 @@ void Canvas::draw_box(const Coordf &p, float size, ColorP color, int layer, bool
     draw_line(p + Coordf(-size, -size), p + Coordf(-size, size), color, layer, tr, width);
 }
 
+void Canvas::draw_bezier2(const Coord<float> &start,const Coord<float> &mid,const Coord<float> &end, ColorP color, int layer , bool tr, uint64_t width){
+    const int segments = 10;
+    int count = segments;
+    if((start.x == mid.x && start.y == mid.y )|| (end.x == mid.x && end.y == mid.y )) { //if mid==start or mid==end, then it is just a line
+        draw_line(start,end, color, layer, tr, width);
+        return;
+    }
+    float t=0;
+    Coord<float> lstart, lend , p0=start, p1;
+
+    while (count--) {
+        t+=1.0/segments;
+        lstart= start+  (mid-start)*t;
+        lend =  mid+ (end-mid)*t;        
+        p1 = lstart + (lend-lstart)* t;
+        draw_line(p0,p1, color, layer, tr,width);
+        p0=p1;
+    }
+}
+
+void Canvas::draw_curve(const Coord<float> &start,const Coord<float> &end,float diviation, ColorP color, int layer , bool tr, uint64_t width){
+    Coord<float> delta = end-start;
+    Coord<float> unit ;
+    unit.x=0; unit.y=1.0;
+    
+    Coord<float> mid= (start + end)*0.5;
+    delta*=diviation;
+    float x = delta.x;
+    delta.x = - delta.y;
+    delta.y = x;
+    mid +=delta;    
+    draw_bezier2(start, mid,end, color,layer,tr, width);
+    
+}
+
+void Canvas::draw_circle(const Coord<float> &center, float radius, ColorP color , int layer , bool tr , uint64_t width ){
+    unsigned int segments = 64;
+    float a0 = 0;
+    float dphi = 2 * M_PI;
+    dphi /= segments;
+    while (segments--) {
+        draw_line(center + Coordf::euler(radius, a0), center + Coordf::euler(radius, a0 + dphi), color, layer, tr,
+                  width);
+        a0 += dphi;
+    }
+}
+
 void Canvas::draw_arc(const Coordf &center, float radius, float a0, float a1, ColorP color, int layer, bool tr,
                       uint64_t width)
 {

--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -48,18 +48,18 @@ void ImpBoard::canvas_update()
 void ImpBoard::update_airwire_annotation()
 {
     airwire_annotation->clear();
-    for (const auto &[net, airwires] : core_board.get_board()->airwires) {
+    for ( auto &[net, airwires] : core_board.get_board()->airwires) {
         if (!airwire_filter_window->airwire_is_visible(net))
             continue;
-        const bool highlight = highlights.count(ObjectRef(ObjectType::NET, net));
+         bool highlight = highlights.count(ObjectRef(ObjectType::NET, net));
         uint8_t color2 = 0;
         if (net_color_map.count(net))
             color2 = net_color_map.at(net);
         if (core_board.tool_is_active() && !highlight && highlights.size())
             continue;
-        for (const auto &airwire : airwires) {
-            airwire_annotation->draw_line(airwire.from.get_position(), airwire.to.get_position(), ColorP::AIRWIRE, 0,
-                                          highlight, color2);
+        for (auto &airwire : airwires) {
+             auto color = airwire.from.get_net()->is_power ?   ColorP::AIRWIRE_ROUTER :ColorP::AIRWIRE;            
+            airwire_annotation->draw_curve(airwire.from.get_position(), airwire.to.get_position(),0.2, color, 0);
         }
     }
 }

--- a/src/import_dxf/dxf_importer.cpp
+++ b/src/import_dxf/dxf_importer.cpp
@@ -134,9 +134,26 @@ private:
             items_unsupported.emplace(type, 0);
     }
 
-    void addCircle(const DL_CircleData &) override
+    void addCircle(const DL_CircleData &d) override
     {
-        add_unsupported(DXFImporter::UnsupportedType::CIRCLE);
+        auto center = get_or_create_junction(d.cx, d.cy);
+        auto from = get_or_create_junction(d.cx - d.radius, d.cy);
+        auto to = get_or_create_junction(d.cx + d.radius, d.cy);
+        auto arc = core->insert_arc(UUID::random());
+
+        arcs_out.insert(arc);
+        arc->layer = layer;
+        arc->width = width;
+        arc->center = center;
+        arc->from = from;
+        arc->to = to;
+        auto arc2 = core->insert_arc(UUID::random());
+        arcs_out.insert(arc2);
+        arc2->layer = layer;
+        arc2->width = width;
+        arc2->center = center;
+        arc2->from = to;
+        arc2->to = from;
     }
 
     void addEllipse(const DL_EllipseData &) override


### PR DESCRIPTION
I have added circle support for DXF import with 2 arcs.
![circle_support_DXF](https://user-images.githubusercontent.com/19941645/103405177-8c3fc100-4b99-11eb-85e8-2702c5c01bc7.png)


And curved airwires and different colored airwires for power net. I hope there is a dedicated color setting for them(currently Router airwire for power net).
![curved_airwire](https://user-images.githubusercontent.com/19941645/103405315-03755500-4b9a-11eb-9d73-684cf04acbe3.png)
I hope there is an option for a user to select between the curved or straight airwire.

