### PR TITLE
Fix compile on 32 bit architecture

### DIFF
--- a/src/dialogs/enter_datum_scale_window.cpp
+++ b/src/dialogs/enter_datum_scale_window.cpp
@@ -33,7 +33,7 @@ EnterDatumScaleWindow::EnterDatumScaleWindow(Gtk::Window *parent, class ImpInter
     add(*box);
 }
 
-double_t EnterDatumScaleWindow::get_value()
+double EnterDatumScaleWindow::get_value()
 {
     return sp->get_value();
 }


### PR DESCRIPTION
fixes build error

[  345s] src/dialogs/enter_datum_scale_window.cpp:36:10: error: no declaration matches 'double_t horizon::EnterDatumScaleWindow::get_value()'
[  345s]    36 | double_t EnterDatumScaleWindow::get_value()
[  345s]       |          ^~~~~~~~~~~~~~~~~~~~~
[  345s] In file included from src/dialogs/enter_datum_scale_window.cpp:1:
[  345s] src/dialogs/enter_datum_scale_window.hpp:19:12: note: candidate is: 'double horizon::EnterDatumScaleWindow::get_value()'
[  345s]    19 |     double get_value();
[  345s]       |            ^~~~~~~~~
[  345s] src/dialogs/enter_datum_scale_window.hpp:15:7: note: 'class horizon::EnterDatumScaleWindow' defined here
[  345s]    15 | class EnterDatumScaleWindow : public ToolWindow {
[  345s]       |       ^~~~~~~~~~~~~~~~~~~~~
[  346s] make: *** [Makefile:948: build/obj/src/dialogs/enter_datum_scale_window.o] Error 1

Signed-off-by: Frank Kunz <mailinglists@kunz-im-inter.net>