### PR TITLE
Dockerfile: add another Dockerfile for building horizon-eda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:buster
+COPY . /src
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+    build-essential \
+    libsqlite3-dev \
+    util-linux \
+    librsvg2-dev \
+    libcairomm-1.0-dev \
+    libepoxy-dev \
+    libgtkmm-3.0-dev \
+    uuid-dev \
+    libboost-dev \
+    libzmq5 \
+    libzmq3-dev \
+    libglm-dev \
+    libgit2-dev \
+    libcurl4-gnutls-dev \
+    liboce-ocaf-dev \
+    libpodofo-dev \
+    python3-dev \
+    libzip-dev \
+    git \
+    python3-cairo-dev \
+    libosmesa6-dev
+
+ENV NVIDIA_VISIBLE_DEVICES all
+# Include "utility" to get nvidia-smi
+ENV NVIDIA_DRIVER_CAPABILITIES graphics,display,utility,compute,video
+
+WORKDIR /src
+RUN make -j$(nproc)
+
+VOLUME /src/horizon-eda
+CMD /src/build/horizon-eda


### PR DESCRIPTION
* it's not perfect, but still could be useful for people like me to try horizon-eda without
  installing all dev dependencies locally
* build with:
  $ docker build . -f Dockerfile -t horizoneda/horizon-eda:latest

* run with:
  docker run --gpus=all \
    -e DISPLAY \
    -e XAUTHORITY=/tmp/.Xauthority \
    -v ${XAUTHORITY}:/tmp/.Xauthority \
    -v /tmp/.X11-unix:/tmp/.X11-unix \
    -v $(pwd)/horizon-eda:/src/horizon-eda \
    -v $(pwd)/horizon-eda/config:/root/.config/horizon \
    -v $(pwd)/horizon-pool:/src/horizon-pool \
    -it horizoneda/horizon-eda:latest

* then save the projects in /src/horizon-eda (instead of the root's HOME
  so that they are save in host's bind

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>