### PR TITLE
Add SQLite temp files to pool's .gitignore

### DIFF
--- a/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
+++ b/src/pool-prj-mgr/pool-mgr/view_create_pool.cpp
@@ -65,6 +65,7 @@ std::pair<bool, std::string> PoolProjectManagerViewCreatePool::create()
         {
             auto ofs = make_ofstream(Glib::build_filename(base_path, ".gitignore"));
             ofs << "*.db\n\
+*.db-*\n\
 tmp/*.json\n\
 3d_models/local\n\
 ";


### PR DESCRIPTION
Some additional files are typically created by SQLite that should
not be committed into git repository:

- parametric.db-shm
- parametric.db-wal
- pool.db-shm
- pool.db-wal

This change adds the *.db-* pattern into generated .gitignore