### PR TITLE
Change default polygon rectangle decoration size

### DIFF
--- a/src/core/tools/tool_draw_polygon_rectangle.hpp
+++ b/src/core/tools/tool_draw_polygon_rectangle.hpp
@@ -50,7 +50,7 @@ private:
     Coordi first_pos;
     Coordi second_pos;
     int step = 0;
-    uint64_t decoration_size = 1_mm;
+    uint64_t decoration_size = 1.2_mm;
     int64_t corner_radius = 0;
 
     class Polygon *temp = nullptr;


### PR DESCRIPTION
When drawing packages I always have to manually change the decoration size for the pin 1 decoration in the assembly layer. This PR changes the default size from 1 mm to 1.2 mm to be in line with the current pool convention’s requirements.