### PR TITLE
Set default corner radius in dual inline footprint generator

### DIFF
--- a/src/imp/footprint_generator/footprint_generator_base.cpp
+++ b/src/imp/footprint_generator/footprint_generator_base.cpp
@@ -36,16 +36,16 @@ FootprintGeneratorBase::FootprintGeneratorBase(const char *resource, IDocumentPa
     overlay->show();
 }
 
-void FootprintGeneratorBase::update_pad_parameters(const Padstack *padstack, Pad &pad, const int64_t pad_width,
+void FootprintGeneratorBase::update_pad_parameters(const Padstack &padstack, Pad &pad, const int64_t pad_width,
                                                    const int64_t pad_height)
 {
-    if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
+    if (padstack.parameter_set.count(ParameterID::PAD_DIAMETER)) {
         pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
     }
     else {
         pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
         pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-        if (padstack->parameter_set.count(ParameterID::CORNER_RADIUS)) {
+        if (padstack.parameter_set.count(ParameterID::CORNER_RADIUS)) {
             const auto r = std::min(0.25_mm, std::min(pad_width, pad_height) / 4);
             pad.parameter_set[ParameterID::CORNER_RADIUS] = r;
         }

--- a/src/imp/footprint_generator/footprint_generator_base.cpp
+++ b/src/imp/footprint_generator/footprint_generator_base.cpp
@@ -35,4 +35,21 @@ FootprintGeneratorBase::FootprintGeneratorBase(const char *resource, IDocumentPa
     pack_start(*overlay, true, true, 0);
     overlay->show();
 }
+
+void FootprintGeneratorBase::update_pad_parameters(const Padstack *padstack, Pad &pad, const int64_t pad_width,
+                                                   const int64_t pad_height)
+{
+    if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
+        pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
+    }
+    else {
+        pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
+        pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
+        if (padstack->parameter_set.count(ParameterID::CORNER_RADIUS)) {
+            const auto r = std::min(0.25_mm, std::min(pad_width, pad_height) / 4);
+            pad.parameter_set[ParameterID::CORNER_RADIUS] = r;
+        }
+    }
+}
+
 } // namespace horizon

--- a/src/imp/footprint_generator/footprint_generator_base.hpp
+++ b/src/imp/footprint_generator/footprint_generator_base.hpp
@@ -7,9 +7,6 @@
 #include <set>
 
 namespace horizon {
-class Pad;
-class Padstack;
-
 class FootprintGeneratorBase : public Gtk::Box {
 public:
     FootprintGeneratorBase(const char *resource, class IDocumentPackage &c);
@@ -29,7 +26,7 @@ protected:
     class IDocumentPackage &core;
     class Package &package;
 
-    virtual void update_pad_parameters(const Padstack &padstack, Pad &pad, const int64_t pad_width,
-                                       const int64_t pad_height);
+    void update_pad_parameters(const class Padstack &padstack, class Pad &pad, const int64_t pad_width,
+                               const int64_t pad_height);
 };
 } // namespace horizon

--- a/src/imp/footprint_generator/footprint_generator_base.hpp
+++ b/src/imp/footprint_generator/footprint_generator_base.hpp
@@ -5,6 +5,8 @@
 #include <array>
 #include <gtkmm.h>
 #include <set>
+#include <package/pad.hpp>
+
 namespace horizon {
 class FootprintGeneratorBase : public Gtk::Box {
 public:
@@ -24,5 +26,8 @@ protected:
     Gtk::Box *box_top = nullptr;
     class IDocumentPackage &core;
     class Package &package;
+
+    virtual void update_pad_parameters(const Padstack *padstack, Pad &pad, const int64_t pad_width,
+                                       const int64_t pad_height);
 };
 } // namespace horizon

--- a/src/imp/footprint_generator/footprint_generator_base.hpp
+++ b/src/imp/footprint_generator/footprint_generator_base.hpp
@@ -5,9 +5,11 @@
 #include <array>
 #include <gtkmm.h>
 #include <set>
-#include <package/pad.hpp>
 
 namespace horizon {
+class Pad;
+class Padstack;
+
 class FootprintGeneratorBase : public Gtk::Box {
 public:
     FootprintGeneratorBase(const char *resource, class IDocumentPackage &c);
@@ -27,7 +29,7 @@ protected:
     class IDocumentPackage &core;
     class Package &package;
 
-    virtual void update_pad_parameters(const Padstack *padstack, Pad &pad, const int64_t pad_width,
+    virtual void update_pad_parameters(const Padstack &padstack, Pad &pad, const int64_t pad_width,
                                        const int64_t pad_height);
 };
 } // namespace horizon

--- a/src/imp/footprint_generator/footprint_generator_dual.cpp
+++ b/src/imp/footprint_generator/footprint_generator_dual.cpp
@@ -148,13 +148,11 @@ bool FootprintGeneratorDual::generate()
             else {
                 pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
                 pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-
                 if (padstack->parameter_set.count(ParameterID::CORNER_RADIUS)) {
                     const int64_t default_radius = 0.1_mm;
-                    const auto r =  std::min(default_radius, std::min(pad_width/2, pad_height/2));
+                    const auto r = std::min(default_radius, std::min(pad_width / 2, pad_height / 2));
                     pad.parameter_set[ParameterID::CORNER_RADIUS] = r;
                 }
-
             }
             if (it < 0)
                 pad.placement.set_angle_deg(270);

--- a/src/imp/footprint_generator/footprint_generator_dual.cpp
+++ b/src/imp/footprint_generator/footprint_generator_dual.cpp
@@ -142,18 +142,7 @@ bool FootprintGeneratorDual::generate()
 
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {it * spacing, y0 - pitch * i};
-            if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
-                pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
-            }
-            else {
-                pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
-                pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-                if (padstack->parameter_set.count(ParameterID::CORNER_RADIUS)) {
-                    const int64_t default_radius = 0.1_mm;
-                    const auto r = std::min(default_radius, std::min(pad_width / 2, pad_height / 2));
-                    pad.parameter_set[ParameterID::CORNER_RADIUS] = r;
-                }
-            }
+            update_pad_parameters(padstack, pad, pad_width, pad_height);
             if (it < 0)
                 pad.placement.set_angle_deg(270);
             else

--- a/src/imp/footprint_generator/footprint_generator_dual.cpp
+++ b/src/imp/footprint_generator/footprint_generator_dual.cpp
@@ -142,7 +142,7 @@ bool FootprintGeneratorDual::generate()
 
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {it * spacing, y0 - pitch * i};
-            update_pad_parameters(padstack, pad, pad_width, pad_height);
+            update_pad_parameters(*padstack, pad, pad_width, pad_height);
             if (it < 0)
                 pad.placement.set_angle_deg(270);
             else

--- a/src/imp/footprint_generator/footprint_generator_dual.cpp
+++ b/src/imp/footprint_generator/footprint_generator_dual.cpp
@@ -148,6 +148,13 @@ bool FootprintGeneratorDual::generate()
             else {
                 pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
                 pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
+
+                if (padstack->parameter_set.count(ParameterID::CORNER_RADIUS)) {
+                    const int64_t default_radius = 0.1_mm;
+                    const auto r =  std::min(default_radius, std::min(pad_width/2, pad_height/2));
+                    pad.parameter_set[ParameterID::CORNER_RADIUS] = r;
+                }
+
             }
             if (it < 0)
                 pad.placement.set_angle_deg(270);

--- a/src/imp/footprint_generator/footprint_generator_grid.cpp
+++ b/src/imp/footprint_generator/footprint_generator_grid.cpp
@@ -136,7 +136,7 @@ bool FootprintGeneratorGrid::generate()
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift.x = pitch_h * x - (pitch_h * (pad_count_h - 1)) / 2;
             pad.placement.shift.y = -pitch_v * y + (pitch_v * (pad_count_v - 1)) / 2;
-            update_pad_parameters(padstack, pad, pad_width, pad_height);
+            update_pad_parameters(*padstack, pad, pad_width, pad_height);
             pad.name = get_bga_letter(x + 1) + std::to_string(y + 1);
         }
     }

--- a/src/imp/footprint_generator/footprint_generator_grid.cpp
+++ b/src/imp/footprint_generator/footprint_generator_grid.cpp
@@ -136,13 +136,7 @@ bool FootprintGeneratorGrid::generate()
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift.x = pitch_h * x - (pitch_h * (pad_count_h - 1)) / 2;
             pad.placement.shift.y = -pitch_v * y + (pitch_v * (pad_count_v - 1)) / 2;
-            if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
-                pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
-            }
-            else {
-                pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
-                pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-            }
+            update_pad_parameters(padstack, pad, pad_width, pad_height);
             pad.name = get_bga_letter(x + 1) + std::to_string(y + 1);
         }
     }

--- a/src/imp/footprint_generator/footprint_generator_quad.cpp
+++ b/src/imp/footprint_generator/footprint_generator_quad.cpp
@@ -104,7 +104,7 @@ bool FootprintGeneratorQuad::generate()
             auto uu = UUID::random();
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {it * spacing_h, y0 - pitch * i};
-            update_pad_parameters(padstack, pad, pad_width, pad_height);
+            update_pad_parameters(*padstack, pad, pad_width, pad_height);
             if (it < 0) {
                 pad.placement.set_angle_deg(270);
                 pad.name = std::to_string(i + 1);
@@ -123,7 +123,7 @@ bool FootprintGeneratorQuad::generate()
             auto uu = UUID::random();
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {x0 + pitch * i, it * spacing_v};
-            update_pad_parameters(padstack, pad, pad_width, pad_height);
+            update_pad_parameters(*padstack, pad, pad_width, pad_height);
             if (it < 0) {
                 pad.placement.set_angle_deg(0);
                 pad.name = std::to_string(i + 1 + pad_count_v);

--- a/src/imp/footprint_generator/footprint_generator_quad.cpp
+++ b/src/imp/footprint_generator/footprint_generator_quad.cpp
@@ -104,13 +104,7 @@ bool FootprintGeneratorQuad::generate()
             auto uu = UUID::random();
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {it * spacing_h, y0 - pitch * i};
-            if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
-                pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
-            }
-            else {
-                pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
-                pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-            }
+            update_pad_parameters(padstack, pad, pad_width, pad_height);
             if (it < 0) {
                 pad.placement.set_angle_deg(270);
                 pad.name = std::to_string(i + 1);
@@ -129,13 +123,7 @@ bool FootprintGeneratorQuad::generate()
             auto uu = UUID::random();
             auto &pad = package.pads.emplace(uu, Pad(uu, padstack)).first->second;
             pad.placement.shift = {x0 + pitch * i, it * spacing_v};
-            if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
-                pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
-            }
-            else {
-                pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
-                pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-            }
+            update_pad_parameters(padstack, pad, pad_width, pad_height);
             if (it < 0) {
                 pad.placement.set_angle_deg(0);
                 pad.name = std::to_string(i + 1 + pad_count_v);

--- a/src/imp/footprint_generator/footprint_generator_single.cpp
+++ b/src/imp/footprint_generator/footprint_generator_single.cpp
@@ -75,7 +75,7 @@ bool FootprintGeneratorSingle::generate()
         pad.placement.shift = {0, y0 - pitch * i};
         pad.placement.set_angle_deg(270);
         pad.name = std::to_string(i + 1);
-        update_pad_parameters(padstack, pad, pad_width, pad_height);
+        update_pad_parameters(*padstack, pad, pad_width, pad_height);
     }
     return true;
 }

--- a/src/imp/footprint_generator/footprint_generator_single.cpp
+++ b/src/imp/footprint_generator/footprint_generator_single.cpp
@@ -75,13 +75,7 @@ bool FootprintGeneratorSingle::generate()
         pad.placement.shift = {0, y0 - pitch * i};
         pad.placement.set_angle_deg(270);
         pad.name = std::to_string(i + 1);
-        if (padstack->parameter_set.count(ParameterID::PAD_DIAMETER)) {
-            pad.parameter_set[ParameterID::PAD_DIAMETER] = std::min(pad_width, pad_height);
-        }
-        else {
-            pad.parameter_set[ParameterID::PAD_HEIGHT] = pad_height;
-            pad.parameter_set[ParameterID::PAD_WIDTH] = pad_width;
-        }
+        update_pad_parameters(padstack, pad, pad_width, pad_height);
     }
     return true;
 }


### PR DESCRIPTION
Currently if using the rounded rect padstack it shows a missing parameter when using the footprint generator.  Might be a better way to do this?  Should I add this to the quad/inline generators as well?

![Peek 2021-06-09 19-11](https://user-images.githubusercontent.com/380158/121440892-c9815980-c956-11eb-9407-10ecdedc75de.gif)
