### PR TITLE
Show deltas in HUD when various items are selected

### DIFF
--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -968,7 +968,11 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
             }
         }
         s += "Total pads: " + std::to_string(n_pads);
-        sel_erase_type(sel, ObjectType::BOARD_PACKAGE);
+
+        // When n == 2 selection is removed when showing delta below
+        if (n != 2) {
+            sel_erase_type(sel, ObjectType::BOARD_PACKAGE);
+        }
     }
     trim(s);
     if (sel_count_type(sel, ObjectType::POLYGON_VERTEX) == 1 || sel_count_type(sel, ObjectType::POLYGON_EDGE) == 1) {
@@ -988,6 +992,48 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
         }
     }
     trim(s);
+
+    // Display the delta if two items of these types are selected
+    for (const ObjectType T : {ObjectType::BOARD_PACKAGE, ObjectType::BOARD_HOLE, ObjectType::VIA}) {
+        if (sel_count_type(sel, T) == 2) {
+            // Already added for packages
+            if (T == ObjectType::BOARD_PACKAGE) {
+                s += "\n";
+            }
+            else {
+                s += "\n\n<b> 2 " + object_descriptions.at(T).get_name_for_n(2) + "</b>\n";
+            }
+            std::vector<Coordi> positions;
+            const auto &brd = *core_board.get_board();
+            for (const auto &it : sel) {
+                if (it.type == T) {
+                    if (T == ObjectType::BOARD_HOLE) {
+                        const auto &hole = &brd.holes.at(it.uuid);
+                        positions.push_back(hole->placement.shift);
+                    }
+                    else if (T == ObjectType::VIA) {
+                        const auto &via = &brd.vias.at(it.uuid);
+                        positions.push_back(via->junction->position);
+                    }
+                    else if (T == ObjectType::BOARD_PACKAGE) {
+                        const auto &package = &brd.packages.at(it.uuid);
+                        positions.push_back(package->placement.shift);
+                    }
+                    else {
+                        assert(false); // unreachable
+                    }
+                }
+            }
+            assert(positions.size() == 2);
+            const auto p1 = positions.at(0);
+            const auto p2 = positions.at(1);
+            s += "ΔX:" + dim_to_string(std::abs(p1.x - p2.x)) + "\n";
+            s += "ΔY:" + dim_to_string(std::abs(p1.y - p2.y));
+            sel_erase_type(sel, T);
+        }
+    }
+    trim(s);
+
     return s;
 }
 

--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -998,7 +998,7 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
         if (sel_count_type(sel, type) == 2) {
             // Already added for packages
             if (type != ObjectType::BOARD_PACKAGE) {
-                s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
+                s += "\n\n<b>2 " + object_descriptions.at(type).name_pl + "</b>";
             }
             std::vector<Coordi> positions;
             const auto &brd = *core_board.get_board();

--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -994,28 +994,25 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
     trim(s);
 
     // Display the delta if two items of these types are selected
-    for (const ObjectType T : {ObjectType::BOARD_PACKAGE, ObjectType::BOARD_HOLE, ObjectType::VIA}) {
-        if (sel_count_type(sel, T) == 2) {
+    for (const ObjectType type : {ObjectType::BOARD_PACKAGE, ObjectType::BOARD_HOLE, ObjectType::VIA}) {
+        if (sel_count_type(sel, type) == 2) {
             // Already added for packages
-            if (T == ObjectType::BOARD_PACKAGE) {
-                s += "\n";
-            }
-            else {
-                s += "\n\n<b> 2 " + object_descriptions.at(T).get_name_for_n(2) + "</b>\n";
+            if (type != ObjectType::BOARD_PACKAGE) {
+                s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
             }
             std::vector<Coordi> positions;
             const auto &brd = *core_board.get_board();
             for (const auto &it : sel) {
-                if (it.type == T) {
-                    if (T == ObjectType::BOARD_HOLE) {
+                if (it.type == type) {
+                    if (type == ObjectType::BOARD_HOLE) {
                         const auto &hole = &brd.holes.at(it.uuid);
                         positions.push_back(hole->placement.shift);
                     }
-                    else if (T == ObjectType::VIA) {
+                    else if (type == ObjectType::VIA) {
                         const auto &via = &brd.vias.at(it.uuid);
                         positions.push_back(via->junction->position);
                     }
-                    else if (T == ObjectType::BOARD_PACKAGE) {
+                    else if (type == ObjectType::BOARD_PACKAGE) {
                         const auto &package = &brd.packages.at(it.uuid);
                         positions.push_back(package->placement.shift);
                     }
@@ -1025,11 +1022,9 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
                 }
             }
             assert(positions.size() == 2);
-            const auto p1 = positions.at(0);
-            const auto p2 = positions.at(1);
-            s += "ΔX:" + dim_to_string(std::abs(p1.x - p2.x)) + "\n";
-            s += "ΔY:" + dim_to_string(std::abs(p1.y - p2.y));
-            sel_erase_type(sel, T);
+            const auto delta = positions.at(1) - positions.at(0);
+            s += "\n" + coord_to_string(delta, true);
+            sel_erase_type(sel, type);
         }
     }
     trim(s);

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -133,7 +133,7 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
     }
 
     // Display the delta if two items of these types are selected
-    for (const ObjectType type : {ObjectType::HOLE, ObjectType::POLYGON_VERTEX}) {
+    for (const ObjectType type : {ObjectType::HOLE, ObjectType::POLYGON_VERTEX, ObjectType::JUNCTION}) {
         if (sel_count_type(sel, type) == 2) {
             s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
             std::vector<Coordi> positions;
@@ -147,6 +147,10 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
                     else if (type == ObjectType::HOLE) {
                         const auto hole = core->get_hole(iter.uuid);
                         positions.push_back(hole->placement.shift);
+                    }
+                    else if (type == ObjectType::JUNCTION) {
+                        const auto junction = core->get_junction(iter.uuid);
+                        positions.push_back(junction->position);
                     }
                     else {
                         assert(false); // unreachable

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -133,7 +133,7 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
     }
 
     // Display the delta if two items of these types are selected
-    for (const ObjectType type: {ObjectType::HOLE, ObjectType::POLYGON_VERTEX}) {
+    for (const ObjectType type : {ObjectType::HOLE, ObjectType::POLYGON_VERTEX}) {
         if (sel_count_type(sel, type) == 2) {
             s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
             std::vector<Coordi> positions;

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -77,6 +77,24 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
             s += "\nVertex: " + std::to_string(it->vertex);
         sel_erase_type(sel, ObjectType::POLYGON_VERTEX);
     }
+    else if (sel_count_type(sel, ObjectType::POLYGON_VERTEX) == 2) {
+        // Display the delta if two verticies are given
+        s += "\n\n<b> 2 " + object_descriptions.at(ObjectType::POLYGON_VERTEX).get_name_for_n(2) + "</b>\n";
+        auto first = sel_find_one(sel, ObjectType::POLYGON_VERTEX);
+        const auto poly = core->get_polygon(first.uuid);
+        std::vector<const Polygon::Vertex *> vertices;
+        for (const auto &iter : sel) {
+            if (iter.type == ObjectType::POLYGON_VERTEX) {
+                vertices.push_back(&poly->vertices.at(iter.vertex));
+            }
+        }
+        assert(vertices.size() == 2);
+        const auto v1 = vertices.at(0);
+        const auto v2 = vertices.at(1);
+        s += "ΔX:" + dim_to_string(std::abs(v1->position.x - v2->position.x)) + "\n";
+        s += "ΔY:" + dim_to_string(std::abs(v1->position.y - v2->position.y));
+        sel_erase_type(sel, ObjectType::POLYGON_VERTEX);
+    }
 
     if (preferences.hud_debug) {
         if (auto it = sel_find_exactly_one(sel, ObjectType::TEXT)) {

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -135,7 +135,7 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
     // Display the delta if two items of these types are selected
     for (const ObjectType type : {ObjectType::HOLE, ObjectType::POLYGON_VERTEX, ObjectType::JUNCTION}) {
         if (sel_count_type(sel, type) == 2) {
-            s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
+            s += "\n\n<b>2 " + object_descriptions.at(type).name_pl + "</b>";
             std::vector<Coordi> positions;
             for (const auto &iter : sel) {
                 if (iter.type == type) {

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -133,18 +133,18 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
     }
 
     // Display the delta if two items of these types are selected
-    for (const ObjectType T : {ObjectType::HOLE, ObjectType::POLYGON_VERTEX}) {
-        if (sel_count_type(sel, T) == 2) {
-            s += "\n\n<b> 2 " + object_descriptions.at(T).get_name_for_n(2) + "</b>\n";
+    for (const ObjectType type: {ObjectType::HOLE, ObjectType::POLYGON_VERTEX}) {
+        if (sel_count_type(sel, type) == 2) {
+            s += "\n\n<b> 2 " + object_descriptions.at(type).name_pl + "</b>";
             std::vector<Coordi> positions;
             for (const auto &iter : sel) {
-                if (iter.type == T) {
-                    if (T == ObjectType::POLYGON_VERTEX) {
+                if (iter.type == type) {
+                    if (type == ObjectType::POLYGON_VERTEX) {
                         const auto poly = core->get_polygon(iter.uuid);
                         const auto vertex = &poly->vertices.at(iter.vertex);
                         positions.push_back(vertex->position);
                     }
-                    else if (T == ObjectType::HOLE) {
+                    else if (type == ObjectType::HOLE) {
                         const auto hole = core->get_hole(iter.uuid);
                         positions.push_back(hole->placement.shift);
                     }
@@ -154,11 +154,9 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
                 }
             }
             assert(positions.size() == 2);
-            const auto p1 = positions.at(0);
-            const auto p2 = positions.at(1);
-            s += "ΔX:" + dim_to_string(std::abs(p1.x - p2.x)) + "\n";
-            s += "ΔY:" + dim_to_string(std::abs(p1.y - p2.y));
-            sel_erase_type(sel, T);
+            const auto delta = positions.at(1) - positions.at(0);
+            s += "\n" + coord_to_string(delta, true);
+            sel_erase_type(sel, type);
         }
     }
 


### PR DESCRIPTION
This will show deltas when exactly 2 items are selected for:

- Packages
- Holes
- Vias
- Polygon vertices

I'm not sure what the difference is between board hole and hole?


![image](https://user-images.githubusercontent.com/380158/121781599-82bc7b00-cb73-11eb-8909-10023aee25ec.png)

![image](https://user-images.githubusercontent.com/380158/121781611-98ca3b80-cb73-11eb-9ccf-adb04e96b19f.png)