### PR TITLE
Use arcs when exporting to pdf

### DIFF
--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -9,6 +9,7 @@
 
 namespace horizon {
 
+
 CanvasPDF::CanvasPDF(PoDoFo::PdfPainterMM &p, PoDoFo::PdfFont &f, const PDFExportSettings &s)
     : Canvas::Canvas(), painter(p), font(f), settings(s), metrics(font.GetFontMetrics())
 {
@@ -155,13 +156,14 @@ void CanvasPDF::img_polygon(const Polygon &ipoly, bool tr)
             }
             else if (last->type == Polygon::Vertex::Type::ARC) {
                 // Finish arc
-                Coordi start = last->position;
-                Coordi c = last->arc_center;
+                Coordd start = last->position;
+                Coordd c = last->arc_center;
+
                 if (tr) {
                     c = transform.transform(c);
                     start = transform.transform(start);
                 }
-                const auto r = ((Coordd) start - (Coordd) c).mag();
+                const auto r = (start - c).mag();
                 if (start == p) {
                     painter.Circle(to_pt(c.x), to_pt(c.y), to_pt(r));
                 }

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -197,79 +197,102 @@ void CanvasPDF::img_hole(const Hole &hole)
     painter.Restore();
 }
 
-// Ported from of PoDoFo::PdfPainter::InternalArc. c is the arc center
+// c0 is the start, c is the arc center.
 // angles must be in radians, c and r must be in a PDF "pt" unit.
-static void pdf_arc_segment(PoDoFo::PdfPainter &painter, const Coordd c, const double r,
-                            const double a0, const double a1, const bool cw)
+// See How to determine the control points of a Bézier curve that approximates a
+// small circular arc by Richard ADeVeneza, Nov 2004
+// https://www.tinaja.com/glib/bezcirc2.pdf
+static Coordd pdf_arc_segment(PoDoFo::PdfPainter &painter,
+                              const Coordd c0, const Coordd c,
+                              const double r,
+                              double a0, double a1,
+                              const bool cw, const bool debug)
 {
-    assert(std::abs(a1 - a0) <= M_PI/2); // A bezier can only approximate an arc of <= 90 deg
-    double delta_angle = (M_PI - static_cast<double>(a0 + a1)) / 2.0f;
-    if (!cw)
-        delta_angle = 2*M_PI - delta_angle;
-    const double new_angle = (static_cast<double>(a1 - a0)/ 2.0f);
-    std::printf("    segment a0=%f a1=%f da=%f na=%f cw=%i\n",
-                a0*180/M_PI, a1*180/M_PI, delta_angle*180/M_PI,
-                new_angle*180/M_PI, cw);
-    const Coordd r0 = Coordd(cos(new_angle) * r, sin(new_angle) * r);
-    const Coordd r2 = Coordd(
-        (r * 4.0f - r0.x) / 3.0f,
-        ((r * 1.0f - r0.y) * (r0.x - r * 3.0f)) / (3.0f* r0.y)
-    );
-    const Coordd r1 = Coordd(r2.x, -r2.y);
-    const Coordd r3 = Coordd(r0.x, -r0.y);
-    const Coordd a = Coordd(sin(delta_angle), cos(delta_angle));
-    const Coordd c1 = Coordd(r1.cross(a), r1.dot(a)) + c;
-    const Coordd c2 = Coordd(r2.cross(a), r2.dot(a)) + c;
-    const Coordd c3 = Coordd(r3.cross(a), r3.dot(a)) + c;
+    const auto da = a0 - a1;
+    assert(da != 0);
+    assert(std::abs(da) <= M_PI/2);
+
+    // Shift to bisect at x axis
+    const auto theta = (a0+a1)/2;
+
+    // At 180 there is a nonlinearity so force the direction
+    //const auto s = sin(theta) > 0;//cw ? 1: -1;
+    //const auto phi = std::abs(da/2)*s;
+    const auto phi = da/2;
+
+    // Compute points of unit circle for given delta angle
+    const auto p0 = Coordd(cos(phi), sin(phi));
+    const auto p1 = Coordd((4-p0.x)/3, (1-p0.x)*(3-p0.x)/(3*p0.y));
+    const auto p2 = Coordd(p1.x, -p1.y);
+    const auto p3 = Coordd(p0.x, -p0.y);
+
+    // Transform points
+    const auto c1 = p1.rotate(theta) * r + c;
+    const auto c2 = p2.rotate(theta) * r + c;
+    const auto c3 = p3.rotate(theta) * r + c;
+
+    // Sanity check
+    if (debug) {// and {
+        const double deg = 180/M_PI;
+        std::printf(
+            "    segment: c=(%f, %f) from a0=%f to a1=%f da=%f theta=%f phi=%f\n",
+            c.x, c.y, a0*deg, a1*deg, da*deg, theta*deg, phi*deg
+        );
+        if ((c0 - c3).mag() < 0.001)
+            std::printf("   ^^ bad\n");
+    }
+
     painter.CubicBezierTo(c1.x, c1.y, c2.x, c2.y, c3.x, c3.y);
+    return c3; // end point
 }
 
 static void pdf_arc(PoDoFo::PdfPainter &painter, const Coordd start, const Coordd c,
-                    const Coordd end, const bool cw)
+                    const Coordd end, bool cw)
 {
     const auto r = to_pt((start - c).mag());
-    const auto ctr = Coordd(to_pt(c.x), to_pt(c.y)) ;
-    double a0 = atan2(start.y - c.y, start.x - c.x);
-    double a1 = atan2(end.y - c.y, end.x - c.x);
-    std::printf("Arc start=%s\n    center=%s\n    end=%s\n    a0=%f a1=%f\n",
-                coord_to_string(start).c_str(),
-                coord_to_string(c).c_str(),
-                coord_to_string(end).c_str(),
-                a0*180/M_PI, a1*180/M_PI);
+    const auto ctr = Coordd(to_pt(c.x), to_pt(c.y));
 
-    if (a0 < 0)
-        a0 += 2*M_PI;
-    if (a1 < 0)
-        a1 += 2*M_PI;
+    // Get angles between 0 and 2*M_PI relative to the x axis
+    double a0 = std::fmod(atan2(start.y - c.y, start.x - c.x)+2*M_PI, 2*M_PI);
+    double a1 = std::fmod(atan2(end.y - c.y, end.x - c.x)+2*M_PI, 2*M_PI);
+    bool debug = true;
 
-    if (cw) {
-        if (a0 >= a1) { // Circle or large arc
-            a1 += 2*M_PI;
-        }
-        assert(a0 < a1);
-    }
-    else {
-        if (a0 >= a1) { // Circle or large arc
-            a1 += 2*M_PI;
-        }
-        assert(a1 > a0);
-    }
-    while (std::abs(a0 - a1) > M_PI/2) {
-        if (cw) {
-            const auto a = a0 + M_PI/2;
-            pdf_arc_segment(painter, ctr, r, a0, a, cw);
-            a0 = a;
-        } else {
-            const auto a = a1 - M_PI/2;
-            pdf_arc_segment(painter, ctr, r, a, a1, cw);
-            a1 = a;
-        }
-    }
     if (a0 != a1) {
-        pdf_arc_segment(painter, ctr, r, a0, a1, cw);
+        std::printf("\n\n\nArc start=(%f, %f) center=(%f, %f) end=(%f, %f) a0=%f a1=%f cw=%i\n",
+                to_pt(start.x), to_pt(start.y),
+                ctr.x, ctr.y,
+                to_pt(end.x), to_pt(end.y),
+                a0*180/M_PI, a1*180/M_PI, cw);
+        debug = true;
+    } else {
+        std::printf("Circle start=(%f, %f) center=(%f, %f) end=(%f, %f) a0=%f a1=%f\n",
+                to_pt(start.x), to_pt(start.y),
+                ctr.x, ctr.y,
+                to_pt(end.x), to_pt(end.y), a0*180/M_PI, a1*180/M_PI);
+    }
+
+    if (a0 == a1) { // Circle
+        a1 += 2*M_PI;
+    }
+    else if (a0 == -a1) {
+        std::printf("  Reverse???\n");
+        //cw = !cw;
+        a1 += 2*M_PI;
+    }
+    else if (a0 > a1) { // Circle
+        a1 += 2*M_PI;
+    }
+    assert(a0 <= a1); // Will not converge
+    Coordd last = Coordd(to_pt(start.x), to_pt(start.y));
+    double &current_angle = (cw) ? a1 : a0;
+    double &stop_angle = (cw) ? a0 : a1;
+    while (std::abs(a1 - a0) > 0) {
+        const auto a = (cw) ? std::max(current_angle - M_PI/2, stop_angle):
+                              std::min(current_angle + M_PI/2, stop_angle);
+        last = pdf_arc_segment(painter, last, ctr, r, current_angle, a, cw, debug);
+        current_angle = a;
     }
 }
-
 
 
 void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
@@ -292,10 +315,8 @@ void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
                 painter.LineToMM(to_um(p.x), to_um(p.y));
         }
         else if (it->type == Polygon::Vertex::Type::ARC) {
-            // Finish arc
             Coordd end = it_next->position;
             Coordd c = it->arc_center;
-
             if (!first)
                 painter.LineToMM(to_um(p.x), to_um(p.y));
 

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -269,14 +269,14 @@ void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
                 }
                 else {
                     if (a0 < a1) {
-                        // Eg a0 = 0 and a0 = 90 but going CCW so we want to
-                        // have a0=90 to a1=360, so swap and add 360
+                        // Eg a0 = 0 and a1 = 90 but going CCW so we want to
+                        // have a0 = 90 to a1 = 360, so swap and add 360
                         std::swap(a0, a1);
                         a1 += 360;
                     }
                     else {
-                        // Eg a0 = 90 and a0 = 0 but going CCW so we want to
-                        // have a0=0 to a1=90 just swap
+                        // Eg a0 = 90 and a1 = 0 but going CCW so we want to
+                        // have a0 = 0 to a1 = 90 just swap
                         std::swap(a0, a1);
                     }
                 }

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -210,10 +210,6 @@ static Coordd pdf_arc_segment(PoDoFo::PdfPainter &painter, const Coordd c, const
 
     // Shift to bisect at x axis
     const auto theta = (a0 + a1) / 2;
-
-    // At 180 there is a nonlinearity so force the direction
-    // const auto s = sin(theta) > 0;//cw ? 1: -1;
-    // const auto phi = std::abs(da/2)*s;
     const auto phi = da / 2;
 
     // Compute points of unit circle for given delta angle

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -252,26 +252,29 @@ void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
                 // ccw for y-negative. This shifts atan2 to match the arc arguments
                 // Note: atan2 args x and y are swapped on purpose
                 const Coordd start = p;
-                const double deg = 180/M_PI;
-                double a0 = std::fmod(atan2(start.x - c.x, start.y - c.y)*deg + 360, 360);
-                double a1 = std::fmod(atan2(end.x - c.x, end.y - c.y)*deg+ 360, 360);
+                const double deg = 180 / M_PI;
+                double a0 = std::fmod(atan2(start.x - c.x, start.y - c.y) * deg + 360, 360);
+                double a1 = std::fmod(atan2(end.x - c.x, end.y - c.y) * deg + 360, 360);
 
                 // Arc only goes clockwise and requires a0 < a1
                 const auto cw = it->arc_reverse;
                 if (cw) {
                     if (a0 < a1) {
                         // No change
-                    } else {
+                    }
+                    else {
                         // Eg a1 = 0 and a0 = 90 --> So make a1 360
                         a1 += 360;
                     }
-                } else {
+                }
+                else {
                     if (a0 < a1) {
                         // Eg a0 = 0 and a0 = 90 but going CCW so we want to
                         // have a0=90 to a1=360, so swap and add 360
                         std::swap(a0, a1);
                         a1 += 360;
-                    } else {
+                    }
+                    else {
                         // Eg a0 = 0 and a0 = 90 but going CCW so we want to
                         // have a0=0 to a1=90 just swap
                         std::swap(a0, a1);

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -275,7 +275,7 @@ void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
                         a1 += 360;
                     }
                     else {
-                        // Eg a0 = 0 and a0 = 90 but going CCW so we want to
+                        // Eg a0 = 90 and a0 = 0 but going CCW so we want to
                         // have a0=0 to a1=90 just swap
                         std::swap(a0, a1);
                     }

--- a/src/export_pdf/canvas_pdf.hpp
+++ b/src/export_pdf/canvas_pdf.hpp
@@ -39,6 +39,7 @@ private:
                        bool center = false, bool mirror = false) override;
     void img_hole(const Hole &hole) override;
     bool pdf_layer_visible(int l) const;
+    void draw_polygon(const Polygon &ipoly, bool tr);
     Color get_pdf_layer_color(int layer) const;
 };
 } // namespace horizon


### PR DESCRIPTION
Instead of converting circles/arcs to polylines this exports them as circles/arcs. This needs more testing but it is working on the SMD rounded rectangular pads and vias. 

1. Should I add an option to toggle it on/off?
2. How can I test the arcs?

After putting them in inkscape and doing a path union:

Before

![image](https://user-images.githubusercontent.com/380158/124186752-c3305a00-da8a-11eb-8ba5-0645334f098c.png)

After

![image](https://user-images.githubusercontent.com/380158/124186812-d9d6b100-da8a-11eb-9a1c-0f6467639273.png)
