### PR TITLE
Add Airwire rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ SRC_COMMON = \
 	src/block_symbol/block_symbol.cpp\
 	src/blocks/dependency_graph.cpp\
 	src/util/installation_uuid.cpp\
+	src/rules/rule_match_component.cpp\
+	src/board/rule_shorted_pads.cpp\
+	src/rules/rule_match_component.cpp\
 
 
 ifeq ($(OS),Windows_NT)
@@ -435,6 +438,7 @@ SRC_IMP = \
 	src/imp/rules/rules_window.cpp\
 	src/imp/rules/rule_editor.cpp\
 	src/imp/rules/rule_match_editor.cpp\
+	src/imp/rules/rule_match_component_editor.cpp\
 	src/imp/rules/rule_match_keepout_editor.cpp\
 	src/imp/rules/rule_editor_hole_size.cpp\
 	src/imp/rules/rule_editor_clearance_silk_exp_copper.cpp\
@@ -449,6 +453,7 @@ SRC_IMP = \
 	src/imp/rules/rule_editor_clearance_copper_keepout.cpp\
 	src/imp/rules/rule_editor_layer_pair.cpp\
 	src/imp/rules/rule_editor_clearance_same_net.cpp\
+	src/imp/rules/rule_editor_shorted_pads.cpp\
 	src/imp/rules/import.cpp\
 	src/imp/rules/export.cpp\
 	src/widgets/location_entry.cpp\

--- a/src/board/board_rules.cpp
+++ b/src/board/board_rules.cpp
@@ -18,6 +18,7 @@ BoardRules::BoardRules(const BoardRules &other)
       rule_clearance_copper_other(other.rule_clearance_copper_other), rule_plane(other.rule_plane),
       rule_diffpair(other.rule_diffpair), rule_clearance_copper_keepout(other.rule_clearance_copper_keepout),
       rule_layer_pair(other.rule_layer_pair), rule_clearance_same_net(other.rule_clearance_same_net),
+      rule_shorted_pads(other.rule_shorted_pads),
       rule_clearance_silkscreen_exposed_copper(other.rule_clearance_silkscreen_exposed_copper),
       rule_parameters(other.rule_parameters), rule_preflight_checks(other.rule_preflight_checks)
 {
@@ -36,6 +37,7 @@ void BoardRules::operator=(const BoardRules &other)
     rule_clearance_copper_keepout = other.rule_clearance_copper_keepout;
     rule_layer_pair = other.rule_layer_pair;
     rule_clearance_same_net = other.rule_clearance_same_net;
+    rule_shorted_pads = other.rule_shorted_pads;
     rule_clearance_silkscreen_exposed_copper = other.rule_clearance_silkscreen_exposed_copper;
     rule_parameters = other.rule_parameters;
     rule_preflight_checks = other.rule_preflight_checks;
@@ -150,6 +152,14 @@ void BoardRules::import_rules(const json &j, const RuleImportMap &import_map)
         }
         fix_order(RuleID::CLEARANCE_SAME_NET);
     }
+    if (j.count("shorted_pads")) {
+        for (const auto &[key, value] : j.at("shorted_pads").items()) {
+            UUID u = key;
+            rule_shorted_pads.emplace(std::piecewise_construct, std::forward_as_tuple(u),
+                                      std::forward_as_tuple(u, value));
+        }
+        fix_order(RuleID::SHORTED_PADS);
+    }
     if (j.count("clearance_silkscreen_exposed_copper")) {
         const json &o = j["clearance_silkscreen_exposed_copper"];
         rule_clearance_silkscreen_exposed_copper = RuleClearanceSilkscreenExposedCopper(o, import_map);
@@ -189,6 +199,9 @@ void BoardRules::cleanup(const Block *block)
         it.second.match.cleanup(block);
     }
     for (auto &it : rule_clearance_same_net) {
+        it.second.match.cleanup(block);
+    }
+    for (auto &it : rule_shorted_pads) {
         it.second.match.cleanup(block);
     }
     for (auto &it : rule_diffpair) {
@@ -256,6 +269,7 @@ json BoardRules::serialize_or_export(Rule::SerializeMode mode) const
     SERIALIZE(via);
     SERIALIZE(plane);
     SERIALIZE(diffpair);
+    SERIALIZE(shorted_pads);
     SERIALIZE(clearance_copper_other);
     SERIALIZE(clearance_copper_keepout);
     SERIALIZE(clearance_same_net);
@@ -285,6 +299,7 @@ std::set<RuleID> BoardRules::get_rule_ids() const
             RuleID::CLEARANCE_COPPER_OTHER,
             RuleID::PLANE,
             RuleID::DIFFPAIR,
+            RuleID::SHORTED_PADS,
             RuleID::PREFLIGHT_CHECKS,
             RuleID::CLEARANCE_COPPER_KEEPOUT,
             RuleID::LAYER_PAIR,
@@ -329,6 +344,8 @@ const Rule *BoardRules::get_rule(RuleID id, const UUID &uu) const
         return &rule_layer_pair.at(uu);
     case RuleID::CLEARANCE_SAME_NET:
         return &rule_clearance_same_net.at(uu);
+    case RuleID::SHORTED_PADS:
+        return &rule_shorted_pads.at(uu);
     default:
         return nullptr;
     }
@@ -396,6 +413,12 @@ std::map<UUID, const Rule *> BoardRules::get_rules(RuleID id) const
         }
         break;
 
+    case RuleID::SHORTED_PADS:
+        for (auto &it : rule_shorted_pads) {
+            r.emplace(it.first, &it.second);
+        }
+        break;
+
     default:;
     }
     return r;
@@ -442,6 +465,10 @@ void BoardRules::remove_rule(RuleID id, const UUID &uu)
 
     case RuleID::CLEARANCE_SAME_NET:
         rule_clearance_same_net.erase(uu);
+        break;
+
+    case RuleID::SHORTED_PADS:
+        rule_shorted_pads.erase(uu);
         break;
 
     default:;
@@ -493,6 +520,10 @@ Rule *BoardRules::add_rule(RuleID id)
 
     case RuleID::CLEARANCE_SAME_NET:
         r = &rule_clearance_same_net.emplace(uu, uu).first->second;
+        break;
+
+    case RuleID::SHORTED_PADS:
+        r = &rule_shorted_pads.emplace(uu, uu).first->second;
         break;
 
     default:

--- a/src/board/board_rules.hpp
+++ b/src/board/board_rules.hpp
@@ -13,6 +13,7 @@
 #include "rule_clearance_copper_keepout.hpp"
 #include "rule_layer_pair.hpp"
 #include "rule_clearance_same_net.hpp"
+#include "rule_shorted_pads.hpp"
 #include "rules/rules.hpp"
 #include "util/uuid.hpp"
 
@@ -74,6 +75,7 @@ private:
     std::map<UUID, RuleClearanceCopperKeepout> rule_clearance_copper_keepout;
     std::map<UUID, RuleLayerPair> rule_layer_pair;
     std::map<UUID, RuleClearanceSameNet> rule_clearance_same_net;
+    std::map<UUID, RuleShortedPads> rule_shorted_pads;
 
     std::vector<const RuleClearanceCopper *> rule_sorted_clearance_copper;
     void update_sorted();

--- a/src/board/rule_clearance_copper.cpp
+++ b/src/board/rule_clearance_copper.cpp
@@ -89,7 +89,7 @@ void RuleClearanceCopper::set_clearance(PatchType a, PatchType b, uint64_t c)
     clearances.at(get_index(a, b)) = c;
 }
 
-std::string RuleClearanceCopper::get_brief(const class Block *block) const
+std::string RuleClearanceCopper::get_brief(const class Block *block, class IPool *pool) const
 {
     std::stringstream ss;
     ss << "1<sup>st</sup> Match " << match_1.get_brief(block) << "\n";

--- a/src/board/rule_clearance_copper.hpp
+++ b/src/board/rule_clearance_copper.hpp
@@ -10,7 +10,7 @@ public:
     RuleClearanceCopper(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
     bool can_export() const override;
 

--- a/src/board/rule_clearance_copper_keepout.cpp
+++ b/src/board/rule_clearance_copper_keepout.cpp
@@ -59,7 +59,7 @@ json RuleClearanceCopperKeepout::serialize() const
     return j;
 }
 
-std::string RuleClearanceCopperKeepout::get_brief(const class Block *block) const
+std::string RuleClearanceCopperKeepout::get_brief(const class Block *block, class IPool *pool) const
 {
     std::stringstream ss;
     ss << "Match " << match.get_brief(block) << "\n";

--- a/src/board/rule_clearance_copper_keepout.hpp
+++ b/src/board/rule_clearance_copper_keepout.hpp
@@ -11,7 +11,7 @@ public:
     RuleClearanceCopperKeepout(const UUID &uu, const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
 
     uint64_t get_clearance(PatchType pt_copper) const;

--- a/src/board/rule_clearance_copper_other.cpp
+++ b/src/board/rule_clearance_copper_other.cpp
@@ -66,7 +66,7 @@ json RuleClearanceCopperOther::serialize() const
     return j;
 }
 
-std::string RuleClearanceCopperOther::get_brief(const class Block *block) const
+std::string RuleClearanceCopperOther::get_brief(const class Block *block, class IPool *pool) const
 {
     std::stringstream ss;
     ss << "Match " << match.get_brief(block) << "\n";

--- a/src/board/rule_clearance_copper_other.hpp
+++ b/src/board/rule_clearance_copper_other.hpp
@@ -10,7 +10,7 @@ public:
     RuleClearanceCopperOther(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
     bool can_export() const override;
 

--- a/src/board/rule_clearance_same_net.cpp
+++ b/src/board/rule_clearance_same_net.cpp
@@ -68,7 +68,7 @@ json RuleClearanceSameNet::serialize() const
     return j;
 }
 
-std::string RuleClearanceSameNet::get_brief(const class Block *block) const
+std::string RuleClearanceSameNet::get_brief(const class Block *block, class IPool *pool) const
 {
     std::stringstream ss;
     ss << "Match " << match.get_brief(block) << "\n";

--- a/src/board/rule_clearance_same_net.hpp
+++ b/src/board/rule_clearance_same_net.hpp
@@ -10,7 +10,7 @@ public:
     RuleClearanceSameNet(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
     bool can_export() const override;
 

--- a/src/board/rule_clearance_silk_exp_copper.cpp
+++ b/src/board/rule_clearance_silk_exp_copper.cpp
@@ -26,7 +26,7 @@ json RuleClearanceSilkscreenExposedCopper::serialize() const
     return j;
 }
 
-std::string RuleClearanceSilkscreenExposedCopper::get_brief(const class Block *block) const
+std::string RuleClearanceSilkscreenExposedCopper::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/board/rule_clearance_silk_exp_copper.hpp
+++ b/src/board/rule_clearance_silk_exp_copper.hpp
@@ -9,7 +9,7 @@ public:
     RuleClearanceSilkscreenExposedCopper(const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 
     uint64_t clearance_top = 0.1_mm;
     uint64_t clearance_bottom = 0.1_mm;

--- a/src/board/rule_diffpair.cpp
+++ b/src/board/rule_diffpair.cpp
@@ -28,7 +28,7 @@ json RuleDiffpair::serialize() const
     return j;
 }
 
-std::string RuleDiffpair::get_brief(const class Block *block) const
+std::string RuleDiffpair::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Net class " + (net_class ? block->net_classes.at(net_class).name : "?");
 }

--- a/src/board/rule_diffpair.hpp
+++ b/src/board/rule_diffpair.hpp
@@ -10,7 +10,7 @@ public:
     RuleDiffpair(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool can_export() const override
     {
         return true;

--- a/src/board/rule_hole_size.cpp
+++ b/src/board/rule_hole_size.cpp
@@ -25,7 +25,7 @@ json RuleHoleSize::serialize() const
     return j;
 }
 
-std::string RuleHoleSize::get_brief(const class Block *block) const
+std::string RuleHoleSize::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Match " + match.get_brief(block);
 }

--- a/src/board/rule_hole_size.hpp
+++ b/src/board/rule_hole_size.hpp
@@ -9,7 +9,7 @@ public:
     RuleHoleSize(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool can_export() const override;
 
     uint64_t diameter_min = 0.1_mm;

--- a/src/board/rule_layer_pair.cpp
+++ b/src/board/rule_layer_pair.cpp
@@ -24,7 +24,7 @@ json RuleLayerPair::serialize() const
     return j;
 }
 
-std::string RuleLayerPair::get_brief(const class Block *block) const
+std::string RuleLayerPair::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Match " + match.get_brief(block);
 }

--- a/src/board/rule_layer_pair.hpp
+++ b/src/board/rule_layer_pair.hpp
@@ -9,7 +9,7 @@ public:
     RuleLayerPair(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool can_export() const override;
 
     RuleMatch match;

--- a/src/board/rule_parameters.cpp
+++ b/src/board/rule_parameters.cpp
@@ -30,7 +30,7 @@ json RuleParameters::serialize() const
     return j;
 }
 
-std::string RuleParameters::get_brief(const class Block *block) const
+std::string RuleParameters::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/board/rule_parameters.hpp
+++ b/src/board/rule_parameters.hpp
@@ -9,7 +9,7 @@ public:
     RuleParameters(const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool can_export() const override
     {
         return true;

--- a/src/board/rule_plane.cpp
+++ b/src/board/rule_plane.cpp
@@ -24,7 +24,7 @@ json RulePlane::serialize() const
     return j;
 }
 
-std::string RulePlane::get_brief(const class Block *block) const
+std::string RulePlane::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Match " + match.get_brief(block) + "\nLayer " + std::to_string(layer);
 }

--- a/src/board/rule_preflight_checks.cpp
+++ b/src/board/rule_preflight_checks.cpp
@@ -20,7 +20,7 @@ json RulePreflightChecks::serialize() const
     return j;
 }
 
-std::string RulePreflightChecks::get_brief(const class Block *block) const
+std::string RulePreflightChecks::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/board/rule_preflight_checks.hpp
+++ b/src/board/rule_preflight_checks.hpp
@@ -9,6 +9,6 @@ public:
     RulePreflightChecks(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 };
 } // namespace horizon

--- a/src/board/rule_shorted_pads.cpp
+++ b/src/board/rule_shorted_pads.cpp
@@ -1,0 +1,46 @@
+#include "rule_shorted_pads.hpp"
+#include "common/lut.hpp"
+#include "util/util.hpp"
+#include <sstream>
+#include "nlohmann/json.hpp"
+
+namespace horizon {
+
+RuleShortedPads::RuleShortedPads(const UUID &uu) : Rule(uu)
+{
+    id = RuleID::SHORTED_PADS;
+}
+
+RuleShortedPads::RuleShortedPads(const UUID &uu, const json &j)
+    : Rule(uu, j), match(j.at("match")), match_component(j.at("match_component"))
+{
+    id = RuleID::SHORTED_PADS;
+}
+
+json RuleShortedPads::serialize() const
+{
+    json j = Rule::serialize();
+    j["match"] = match.serialize();
+    j["match_component"] = match_component.serialize();
+    return j;
+}
+
+bool RuleShortedPads::matches(const class Component *component, const class Net *net) const
+{
+    return match_component.matches(component) && match.match(net);
+}
+
+std::string RuleShortedPads::get_brief(const class Block *block, class IPool *pool) const
+{
+    std::stringstream ss;
+    ss << "Match " << match_component.get_brief(block, pool) << "\n";
+    ss << "  " << match.get_brief(block);
+    return ss.str();
+}
+
+bool RuleShortedPads::can_export() const
+{
+    return match.can_export() && match_component.can_export();
+}
+
+} // namespace horizon

--- a/src/board/rule_shorted_pads.hpp
+++ b/src/board/rule_shorted_pads.hpp
@@ -1,23 +1,23 @@
 #pragma once
 #include "common/common.hpp"
-#include "plane.hpp"
 #include "rules/rule.hpp"
 #include "rules/rule_match.hpp"
+#include "rules/rule_match_component.hpp"
+#include <set>
 
 namespace horizon {
-class RulePlane : public Rule {
+class RuleShortedPads : public Rule {
 public:
-    RulePlane(const UUID &uu);
-    RulePlane(const UUID &uu, const json &j, const RuleImportMap &import_map);
+    RuleShortedPads(const UUID &uu);
+    RuleShortedPads(const UUID &uu, const json &j);
     json serialize() const override;
 
     std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
-    bool is_match_all() const override;
     bool can_export() const override;
 
-    RuleMatch match;
-    int layer = 10000;
+    bool matches(const class Component *component, const class Net *net) const;
 
-    PlaneSettings settings;
+    RuleMatch match;
+    RuleMatchComponent match_component;
 };
 } // namespace horizon

--- a/src/board/rule_track_width.cpp
+++ b/src/board/rule_track_width.cpp
@@ -50,7 +50,7 @@ json RuleTrackWidth::serialize() const
     return j;
 }
 
-std::string RuleTrackWidth::get_brief(const class Block *block) const
+std::string RuleTrackWidth::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Match " + match.get_brief(block);
 }

--- a/src/board/rule_track_width.hpp
+++ b/src/board/rule_track_width.hpp
@@ -21,7 +21,7 @@ public:
     RuleTrackWidth(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
     bool can_export() const override;
 

--- a/src/board/rule_via.cpp
+++ b/src/board/rule_via.cpp
@@ -27,7 +27,7 @@ json RuleVia::serialize() const
     return j;
 }
 
-std::string RuleVia::get_brief(const class Block *block) const
+std::string RuleVia::get_brief(const class Block *block, class IPool *pool) const
 {
     return "Match " + match.get_brief(block);
 }

--- a/src/board/rule_via.hpp
+++ b/src/board/rule_via.hpp
@@ -11,7 +11,7 @@ public:
     RuleVia(const UUID &uu, const json &j, const RuleImportMap &import_map);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
     bool is_match_all() const override;
     bool can_export() const override;
 

--- a/src/imp/rules/rule_editor_shorted_pads.cpp
+++ b/src/imp/rules/rule_editor_shorted_pads.cpp
@@ -1,0 +1,50 @@
+#include "rule_editor_shorted_pads.hpp"
+#include "board/rule_shorted_pads.hpp"
+#include "rules/rule_match_component.hpp"
+#include "rule_match_component_editor.hpp"
+#include "rule_match_editor.hpp"
+
+namespace horizon {
+void RuleEditorShortedPads::populate()
+{
+    rule2 = &dynamic_cast<RuleShortedPads &>(rule);
+
+    auto editor = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 20));
+    editor->set_margin_start(20);
+    editor->set_margin_end(20);
+    editor->set_margin_bottom(20);
+
+    auto grid = Gtk::manage(new Gtk::Grid());
+    grid->set_row_spacing(10);
+    grid->set_column_spacing(20);
+
+    {
+        auto la = Gtk::manage(new Gtk::Label("Match Component"));
+        la->get_style_context()->add_class("dim-label");
+        la->set_halign(Gtk::ALIGN_START);
+        grid->attach(*la, 0, 0, 1, 1);
+    }
+    {
+        auto la = Gtk::manage(new Gtk::Label("Match Net"));
+        la->get_style_context()->add_class("dim-label");
+        la->set_halign(Gtk::ALIGN_START);
+        grid->attach(*la, 1, 0, 1, 1);
+    }
+
+    auto match_component_editor = Gtk::manage(new RuleMatchComponentEditor(rule2->match_component, core));
+    match_component_editor->set_orientation(Gtk::ORIENTATION_HORIZONTAL);
+    match_component_editor->signal_updated().connect([this] { s_signal_updated.emit(); });
+    grid->attach(*match_component_editor, 0, 1, 1, 1);
+
+    auto match_editor = Gtk::manage(new RuleMatchEditor(rule2->match, core));
+    match_editor->set_orientation(Gtk::ORIENTATION_HORIZONTAL);
+    match_editor->signal_updated().connect([this] { s_signal_updated.emit(); });
+    grid->attach(*match_editor, 1, 1, 1, 1);
+
+    grid->show_all();
+    editor->pack_start(*grid, false, false, 0);
+
+    pack_start(*editor, true, true, 0);
+    editor->show();
+}
+} // namespace horizon

--- a/src/imp/rules/rule_editor_shorted_pads.hpp
+++ b/src/imp/rules/rule_editor_shorted_pads.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "rule_editor.hpp"
+
+namespace horizon {
+class RuleEditorShortedPads : public RuleEditor {
+    using RuleEditor::RuleEditor;
+
+public:
+    void populate() override;
+
+private:
+    class RuleShortedPads *rule2;
+};
+} // namespace horizon

--- a/src/imp/rules/rule_match_component_editor.cpp
+++ b/src/imp/rules/rule_match_component_editor.cpp
@@ -1,0 +1,49 @@
+#include "rule_match_component_editor.hpp"
+#include "block/block.hpp"
+#include "document/idocument.hpp"
+#include "rules/rule_match_component.hpp"
+#include "widgets/component_button.hpp"
+#include "widgets/pool_browser_button.hpp"
+
+namespace horizon {
+RuleMatchComponentEditor::RuleMatchComponentEditor(RuleMatchComponent &ma, class IDocument &c)
+    : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 4), match(ma), core(c)
+{
+    combo_mode = Gtk::manage(new Gtk::ComboBoxText());
+    combo_mode->append(std::to_string(static_cast<int>(RuleMatchComponent::Mode::COMPONENT)), "Component");
+    combo_mode->append(std::to_string(static_cast<int>(RuleMatchComponent::Mode::PART)), "Part");
+    combo_mode->set_active_id(std::to_string(static_cast<int>(match.mode)));
+    combo_mode->signal_changed().connect([this] {
+        match.mode = static_cast<RuleMatchComponent::Mode>(std::stoi(combo_mode->get_active_id()));
+        sel_stack->set_visible_child(combo_mode->get_active_id());
+        s_signal_updated.emit();
+    });
+
+    pack_start(*combo_mode, true, true, 0);
+    combo_mode->show();
+
+    sel_stack = Gtk::manage(new Gtk::Stack());
+    sel_stack->set_homogeneous(true);
+
+    component_button = Gtk::manage(new ComponentButton(core.get_top_block()));
+    component_button->set_component(match.component);
+    component_button->signal_changed().connect([this](const UUID &uu) {
+        match.component = uu;
+        s_signal_updated.emit();
+    });
+    sel_stack->add(*component_button, std::to_string(static_cast<int>(RuleMatchComponent::Mode::COMPONENT)));
+
+    part_button = Gtk::manage(new PoolBrowserButton(ObjectType::PART, core.get_pool()));
+    part_button->property_selected_uuid().set_value(match.part);
+    part_button->property_selected_uuid().signal_changed().connect([this] {
+        match.part = part_button->property_selected_uuid().get_value();
+        s_signal_updated.emit();
+    });
+    sel_stack->add(*part_button, std::to_string(static_cast<int>(RuleMatchComponent::Mode::PART)));
+
+    pack_start(*sel_stack, true, true, 0);
+    sel_stack->show_all();
+
+    sel_stack->set_visible_child(std::to_string(static_cast<int>(match.mode)));
+}
+} // namespace horizon

--- a/src/imp/rules/rule_match_component_editor.hpp
+++ b/src/imp/rules/rule_match_component_editor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <gtkmm.h>
+
+namespace horizon {
+class RuleMatchComponentEditor : public Gtk::Box {
+public:
+    RuleMatchComponentEditor(class RuleMatchComponent &ma, class IDocument &c);
+    typedef sigc::signal<void> type_signal_updated;
+    type_signal_updated signal_updated()
+    {
+        return s_signal_updated;
+    }
+
+private:
+    Gtk::ComboBoxText *combo_mode = nullptr;
+    Gtk::Stack *sel_stack = nullptr;
+    class ComponentButton *component_button = nullptr;
+    class PoolBrowserButton *part_button = nullptr;
+    RuleMatchComponent &match;
+    class IDocument &core;
+    type_signal_updated s_signal_updated;
+};
+} // namespace horizon

--- a/src/imp/rules/rules_window.cpp
+++ b/src/imp/rules/rules_window.cpp
@@ -15,6 +15,7 @@
 #include "rule_editor_clearance_copper_keepout.hpp"
 #include "rule_editor_layer_pair.hpp"
 #include "rule_editor_clearance_same_net.hpp"
+#include "rule_editor_shorted_pads.hpp"
 #include "rules/cache.hpp"
 #include "rules/rule_descr.hpp"
 #include "rules/rules.hpp"
@@ -619,6 +620,10 @@ RuleEditor *RulesWindow::create_editor(Rule &r)
         e = new RuleEditorClearanceSameNet(r, core);
         break;
 
+    case RuleID::SHORTED_PADS:
+        e = new RuleEditorShortedPads(r, core);
+        break;
+
     default:
         e = new RuleEditor(r, core);
     }
@@ -643,8 +648,8 @@ void RulesWindow::update_rule_instances(RuleID id)
         delete it;
     }
     for (const auto &it : inst) {
-        auto la = Gtk::manage(
-                new RuleLabel(sg_order, it.second->get_brief(get_top_block()), id, it.first, it.second->get_order()));
+        auto la = Gtk::manage(new RuleLabel(sg_order, it.second->get_brief(get_top_block(), &core.get_pool()), id,
+                                            it.first, it.second->get_order()));
         la->set_sensitive(it.second->enabled);
         la->set_imported(it.second->imported);
         la->show();
@@ -665,7 +670,7 @@ void RulesWindow::update_rule_instance_labels()
     for (auto ch : lb_multi->get_children()) {
         auto la = dynamic_cast<RuleLabel *>(dynamic_cast<Gtk::ListBoxRow *>(ch)->get_child());
         auto rule = rules.get_rule(la->id, la->uuid);
-        la->set_text(rule->get_brief(get_top_block()));
+        la->set_text(rule->get_brief(get_top_block(), &core.get_pool()));
         la->set_sensitive(rule->enabled);
         la->set_order(rule->get_order());
         la->set_imported(rule->imported);

--- a/src/package/rule_clearance_package.cpp
+++ b/src/package/rule_clearance_package.cpp
@@ -23,7 +23,7 @@ json RuleClearancePackage::serialize() const
     return j;
 }
 
-std::string RuleClearancePackage::get_brief(const class Block *block) const
+std::string RuleClearancePackage::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/package/rule_clearance_package.hpp
+++ b/src/package/rule_clearance_package.hpp
@@ -9,7 +9,7 @@ public:
     RuleClearancePackage(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 
     uint64_t clearance_silkscreen_cu = 0.2_mm;
     uint64_t clearance_silkscreen_pkg = 0.2_mm;

--- a/src/package/rule_package_checks.cpp
+++ b/src/package/rule_package_checks.cpp
@@ -20,7 +20,7 @@ json RulePackageChecks::serialize() const
     return j;
 }
 
-std::string RulePackageChecks::get_brief(const class Block *block) const
+std::string RulePackageChecks::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/package/rule_package_checks.hpp
+++ b/src/package/rule_package_checks.hpp
@@ -9,6 +9,6 @@ public:
     RulePackageChecks(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 };
 } // namespace horizon

--- a/src/rules/rule.hpp
+++ b/src/rules/rule.hpp
@@ -20,6 +20,7 @@ enum class RuleID {
     PLANE,
     DIFFPAIR,
     PACKAGE_CHECKS,
+    SHORTED_PADS,
     PREFLIGHT_CHECKS,
     CLEARANCE_COPPER_KEEPOUT,
     LAYER_PAIR,
@@ -69,7 +70,7 @@ public:
     }
 
     virtual json serialize() const;
-    virtual std::string get_brief(const class Block *block = nullptr) const = 0;
+    virtual std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const = 0;
     virtual bool is_match_all() const
     {
         return false;

--- a/src/rules/rule_descr.cpp
+++ b/src/rules/rule_descr.cpp
@@ -28,6 +28,8 @@ const std::map<RuleID, RD> rule_descriptions = {
 
         {RuleID::PACKAGE_CHECKS, {"Package checks", RD::CAN_CHECK}},
 
+        {RuleID::SHORTED_PADS, {"Shorted Pads", RD::IS_MULTI}},
+
         {RuleID::PREFLIGHT_CHECKS, {"Preflight checks", RD::CAN_CHECK}},
 
         {RuleID::CLEARANCE_COPPER_KEEPOUT,

--- a/src/rules/rule_match_component.cpp
+++ b/src/rules/rule_match_component.cpp
@@ -1,0 +1,97 @@
+#include "rule_match_component.hpp"
+#include "block/block.hpp"
+#include "pool/pool.hpp"
+#include "pool/part.hpp"
+#include "block/net.hpp"
+#include "common/lut.hpp"
+#include <glibmm.h>
+#include "nlohmann/json.hpp"
+#include "rule.hpp"
+
+namespace horizon {
+static const LutEnumStr<RuleMatchComponent::Mode> mode_lut = {
+        {"component", RuleMatchComponent::Mode::COMPONENT},
+        {"part", RuleMatchComponent::Mode::PART},
+};
+
+RuleMatchComponent::RuleMatchComponent()
+{
+}
+
+RuleMatchComponent::RuleMatchComponent(const json &j)
+    : mode(mode_lut.lookup(j.at("mode"))), component(j.at("component").get<std::string>()),
+      part(j.at("part").get<std::string>())
+{
+}
+
+json RuleMatchComponent::serialize() const
+{
+    json j;
+    j["mode"] = mode_lut.lookup_reverse(mode);
+    j["component"] = static_cast<std::string>(component);
+    j["part"] = static_cast<std::string>(part);
+
+    return j;
+}
+
+bool RuleMatchComponent::match(const Component *c) const
+{
+    switch (mode) {
+    case Mode::COMPONENT:
+        return c && c->uuid == component;
+
+    case Mode::PART:
+        return c && c->part && c->part->uuid == part;
+    }
+    return false;
+}
+
+void RuleMatchComponent::cleanup(const Block *block)
+{
+    if (!block->components.count(component))
+        component = UUID();
+}
+
+bool RuleMatchComponent::matches(const class Component *c) const
+{
+    switch (mode) {
+    case Mode::COMPONENT:
+        return c->uuid == component;
+    case Mode::PART:
+        return c->part->get_uuid() == part;
+    }
+    return false;
+}
+
+std::string RuleMatchComponent::get_brief(const Block *block, IPool *pool) const
+{
+    switch (mode) {
+    case Mode::COMPONENT:
+        if (block) {
+            return "Component " + (component ? block->components.at(component).refdes : "?");
+        }
+        else {
+            return "Component";
+        }
+    case Mode::PART:
+        if (pool) {
+            return "Part " + (part ? pool->get_part(part)->get_MPN() : "?");
+        }
+        else {
+            return "Part";
+        }
+    }
+    return "";
+}
+
+bool RuleMatchComponent::can_export() const
+{
+    switch (mode) {
+    case Mode::PART:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace horizon

--- a/src/rules/rule_match_component.hpp
+++ b/src/rules/rule_match_component.hpp
@@ -5,19 +5,23 @@
 namespace horizon {
 using json = nlohmann::json;
 
-class RuleMatchKeepout {
+class RuleMatchComponent {
 public:
-    RuleMatchKeepout();
-    RuleMatchKeepout(const json &j);
+    RuleMatchComponent();
+    RuleMatchComponent(const json &j);
     json serialize() const;
     std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const;
     void cleanup(const class Block *block);
-    bool match(const class KeepoutContour *contour) const;
+    bool can_export() const;
 
-    enum class Mode { ALL, KEEPOUT_CLASS, COMPONENT };
-    Mode mode = Mode::ALL;
+    bool matches(const class Component *component) const;
 
-    std::string keepout_class;
+    enum class Mode { COMPONENT, PART };
+    Mode mode = Mode::COMPONENT;
+
     UUID component;
+    UUID part;
+
+    bool match(const class Component *component) const;
 };
 } // namespace horizon

--- a/src/rules/rule_match_keepout.cpp
+++ b/src/rules/rule_match_keepout.cpp
@@ -57,7 +57,7 @@ bool RuleMatchKeepout::match(const KeepoutContour *contour) const
     }
 }
 
-std::string RuleMatchKeepout::get_brief(const Block *block) const
+std::string RuleMatchKeepout::get_brief(const Block *block, class IPool *pool) const
 {
     if (block) {
         switch (mode) {

--- a/src/schematic/rule_single_pin_net.cpp
+++ b/src/schematic/rule_single_pin_net.cpp
@@ -22,7 +22,7 @@ json RuleSinglePinNet::serialize() const
     return j;
 }
 
-std::string RuleSinglePinNet::get_brief(const class Block *block) const
+std::string RuleSinglePinNet::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/schematic/rule_single_pin_net.hpp
+++ b/src/schematic/rule_single_pin_net.hpp
@@ -8,7 +8,7 @@ public:
     RuleSinglePinNet(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 
     bool include_unnamed = true;
 };

--- a/src/symbol/rule_symbol_checks.cpp
+++ b/src/symbol/rule_symbol_checks.cpp
@@ -20,7 +20,7 @@ json RuleSymbolChecks::serialize() const
     return j;
 }
 
-std::string RuleSymbolChecks::get_brief(const class Block *block) const
+std::string RuleSymbolChecks::get_brief(const class Block *block, class IPool *pool) const
 {
     return "";
 }

--- a/src/symbol/rule_symbol_checks.hpp
+++ b/src/symbol/rule_symbol_checks.hpp
@@ -9,6 +9,6 @@ public:
     RuleSymbolChecks(const json &j);
     json serialize() const override;
 
-    std::string get_brief(const class Block *block = nullptr) const override;
+    std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 };
 } // namespace horizon


### PR DESCRIPTION
These rules allow the user to specify components/parts that should be
considered as shortened for airwires. For example a 0 Ohm bridge
required for 1 layer boards should be considered as a connection and
result in an airwire spanning across it.