### PR TITLE
Implement RuleClearanceSilkscreenExposedCopper

### DIFF
--- a/scripts/app_versions.yml
+++ b/scripts/app_versions.yml
@@ -5,6 +5,7 @@ versions:
     3: add silkscreen color
     4: add rule net class regex matching
     5: add shorted pads rule
+    6: add pads only flag to silkscreen exposed copper rule
   schematic:
     1: add custom values on symbols
     2: add hierarchy

--- a/src/board/board.cpp
+++ b/src/board/board.cpp
@@ -33,7 +33,7 @@ BoardColors::BoardColors() : solder_mask({0, .5, 0}), silkscreen({1, 1, 1}), sub
 {
 }
 
-static const unsigned int app_version = 5;
+static const unsigned int app_version = 6;
 
 unsigned int Board::get_app_version()
 {

--- a/src/board/board_rules.hpp
+++ b/src/board/board_rules.hpp
@@ -90,6 +90,8 @@ private:
                                             check_status_cb_t status_cb) const;
     RulesCheckResult check_clearance_copper_non_copper(const class Board &b, class RulesCheckCache &cache,
                                                        check_status_cb_t status_cb) const;
+    RulesCheckResult check_clearance_silkscreen_exposed_copper(const class Board &b, class RulesCheckCache &cache,
+                                                               check_status_cb_t status_cb) const;
     RulesCheckResult check_preflight(const class Board &b) const;
     RulesCheckResult check_clearance_copper_keepout(const class Board &b, class RulesCheckCache &cache,
                                                     check_status_cb_t status_cb) const;

--- a/src/board/rule_clearance_silk_exp_copper.cpp
+++ b/src/board/rule_clearance_silk_exp_copper.cpp
@@ -14,11 +14,13 @@ RuleClearanceSilkscreenExposedCopper::RuleClearanceSilkscreenExposedCopper(const
 {
     clearance_top = j.at("clearance_top").get<uint64_t>();
     clearance_bottom = j.at("clearance_bottom").get<uint64_t>();
+    pads_only = j.value("pads_only", false);
 }
 
 json RuleClearanceSilkscreenExposedCopper::serialize() const
 {
     json j = Rule::serialize();
+    j["pads_only"] = pads_only;
     j["clearance_top"] = clearance_top;
     j["clearance_bottom"] = clearance_bottom;
     return j;

--- a/src/board/rule_clearance_silk_exp_copper.hpp
+++ b/src/board/rule_clearance_silk_exp_copper.hpp
@@ -17,6 +17,7 @@ public:
 
     std::string get_brief(const class Block *block = nullptr, class IPool *pool = nullptr) const override;
 
+    bool pads_only = false;
     uint64_t clearance_top = 0.1_mm;
     uint64_t clearance_bottom = 0.1_mm;
 };

--- a/src/imp/rules/rule_editor_clearance_silk_exp_copper.cpp
+++ b/src/imp/rules/rule_editor_clearance_silk_exp_copper.cpp
@@ -47,6 +47,14 @@ void RuleEditorClearanceSilkscreenExposedCopper::populate()
             rule1->clearance_bottom = sp_bot->get_value_as_int();
             s_signal_updated.emit();
         });
+
+        auto cb_pads_only = Gtk::manage(new Gtk::CheckButton("Pads only"));
+        cb_pads_only->set_active(rule1->pads_only);
+        cb_pads_only->signal_toggled().connect([this, cb_pads_only, rule1] {
+            rule1->pads_only = cb_pads_only->get_active();
+            s_signal_updated.emit();
+        });
+        grid->attach(*cb_pads_only, 0, top, 1, 1);
     }
     if (auto rule2 = dynamic_cast<RuleParameters *>(&rule)) {
         auto sp_solder = create_sp_dim("Solder mask expansion");

--- a/src/rules/rule_descr.cpp
+++ b/src/rules/rule_descr.cpp
@@ -11,7 +11,7 @@ const std::map<RuleID, RD> rule_descriptions = {
 
         {RuleID::CLEARANCE_COPPER, {"Copper clearance", RD::IS_MULTI | RD::CAN_CHECK | RD::NEEDS_MATCH_ALL}},
 
-        {RuleID::CLEARANCE_SILKSCREEN_EXPOSED_COPPER, {"Clearance\nSilkscreen - Exposed copper", 0}},
+        {RuleID::CLEARANCE_SILKSCREEN_EXPOSED_COPPER, {"Clearance\nSilkscreen - Exposed copper", RD::CAN_CHECK}},
 
         {RuleID::PARAMETERS, {"Parameters", RD::CAN_APPLY}},
 


### PR DESCRIPTION
Also adds the pads_only flag to the rule to only complain about pads and
not traces close to silkscreen.

This resulted in an board app_version bump.