### PR TITLE
3d view: Keep silkscreen over tented vias for #630

### DIFF
--- a/src/canvas3d/canvas_mesh.hpp
+++ b/src/canvas3d/canvas_mesh.hpp
@@ -40,6 +40,7 @@ private:
     void polynode_to_tris(const ClipperLib::PolyNode *node, int layer);
     void prepare_layer(int layer);
     void prepare_soldermask(int layer);
+    void prepare_silkscreen(int layer, int soldermask_layer);
     void add_path(int layer, const ClipperLib::Path &path);
 };
 } // namespace horizon


### PR DESCRIPTION
I couldn't figure out how to invert the solder mask layer... but I think this gives the same result? 

![image](https://user-images.githubusercontent.com/380158/144926422-6d1acbe0-3b13-4f17-b35c-9230889ce31d.png)

Should it also subtract the paste layer?