### PR TITLE
Add touchpad gesture rotation with configurable snap threshold

### DIFF
--- a/src/imp/imp_layer.cpp
+++ b/src/imp/imp_layer.cpp
@@ -138,6 +138,20 @@ void ImpLayer::add_view_angle_actions()
             false);
     box->pack_start(*view_angle_button, true, true, 0);
 
+    gesture_rotate = Gtk::GestureRotate::create(*canvas);
+    gesture_rotate->signal_begin().connect([this](GdkEventSequence *seq) { gesture_rotate_angle_orig = view_angle; });
+    gesture_rotate->signal_update().connect([this](GdkEventSequence *seq) {
+        auto angle = gesture_rotate_angle_orig - angle_from_rad(gesture_rotate->get_angle_delta());
+        constexpr int snap_points[] = {0, 16384, 32768, 49152, 65536};
+        for (int p : snap_points) {
+            if (std::abs(angle - p) < (preferences.zoom.touchpad_rotate_snap_threshold * 65536) / 360) {
+                angle = p;
+                break;
+            }
+        }
+        set_view_angle(angle);
+    });
+
     auto right_button = Gtk::manage(new Gtk::Button);
     right_button->set_image_from_icon_name("object-rotate-right-symbolic");
     right_button->signal_clicked().connect([this] { trigger_action(ActionID::ROTATE_VIEW_RIGHT); });

--- a/src/imp/imp_layer.hpp
+++ b/src/imp/imp_layer.hpp
@@ -40,6 +40,8 @@ protected:
     void set_view_angle(int angle);
     Gtk::Label *view_angle_label = nullptr;
     Gtk::Button *view_angle_button = nullptr;
+    Glib::RefPtr<Gtk::GestureRotate> gesture_rotate;
+    int gesture_rotate_angle_orig = 1;
 
     class ViewAngleWindow *view_angle_window = nullptr;
     sigc::connection view_angle_window_conn;

--- a/src/pool-prj-mgr/preferences/preferences_window_misc.cpp
+++ b/src/pool-prj-mgr/preferences/preferences_window_misc.cpp
@@ -262,6 +262,25 @@ MiscPreferencesEditor::MiscPreferencesEditor(Preferences &prefs) : preferences(p
                                                         preferences, preferences.zoom.touchpad_pan));
             gr->add_row(*r);
         }
+
+        {
+            auto r = Gtk::manage(new PreferencesRowNumeric<int>(
+                    "Touchpad rotate snap threshold",
+                    "How aggressively to snap to 90-degree angles when rotating with touchpad gestures", preferences,
+                    preferences.zoom.touchpad_rotate_snap_threshold));
+            auto &sp = r->get_spinbutton();
+            sp.set_range(0, 360);
+            sp.set_increments(1, 1);
+            sp.set_width_chars(5);
+            sp.set_alignment(1);
+            sp.signal_output().connect([&sp] {
+                int v = sp.get_value_as_int();
+                sp.set_text(std::to_string(v) + " °");
+                return true;
+            });
+            r->bind();
+            gr->add_row(*r);
+        }
         {
             auto r = Gtk::manage(new PreferencesRowBoolButton("Keyboard zoom center", "Where to zoom in using keyboard",
                                                               "Cursor", "Screen center", preferences,

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -215,6 +215,7 @@ json ZoomPreferences::serialize() const
     j["smooth_zoom_3d"] = smooth_zoom_3d;
     j["touchpad_pan"] = touchpad_pan;
     j["zoom_factor"] = zoom_factor;
+    j["touchpad_rotate_snap_threshold"] = touchpad_rotate_snap_threshold;
     j["keyboard_zoom_to_cursor"] = keyboard_zoom_to_cursor;
     return j;
 }
@@ -225,6 +226,7 @@ void ZoomPreferences::load_from_json(const json &j)
     smooth_zoom_3d = j.value("smooth_zoom_3d", false);
     touchpad_pan = j.value("touchpad_pan", false);
     zoom_factor = j.value("zoom_factor", 50);
+    touchpad_rotate_snap_threshold = j.value("touchpad_rotate_snap_threshold", 15);
     keyboard_zoom_to_cursor = j.value("keyboard_zoom_to_cursor", false);
 }
 

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -65,6 +65,7 @@ public:
     bool smooth_zoom_3d = false;
     bool touchpad_pan = false;
     float zoom_factor = 50;
+    int touchpad_rotate_snap_threshold = 15;
     bool keyboard_zoom_to_cursor = false;
 
     void load_from_json(const json &j);


### PR DESCRIPTION
Because why not. Certainly feels more convenient to me than going into the menu thing :)
To prevent accidental rotation while just zooming, a relatively large snap threshold is used by default.
If someone wishes to *completely* avoid the rotation, a huge threshold could be set.

(Other gestures are handled in the canvas but maybe they should be here in imp_layer too, e.g. if zoom would get a similar UI element as rotation has…)