### PR TITLE
Update make_help.py

### DIFF
--- a/scripts/make_help.py
+++ b/scripts/make_help.py
@@ -4,7 +4,7 @@ infile = sys.argv[2]
 
 texts = {}
 text_current = None
-for line in open(infile, "r") :
+for line in open(infile, "r", encoding="UTF-8") :
 	line = line.strip()
 	if line.startswith("#") :
 		text_current = line[1:]


### PR DESCRIPTION
Hi, Horizon developers
I encounter the following error when building horizon-eda on Windows10:
```
build/gen/help_texts.hpp
Traceback (most recent call last):
  File ".......\horizon-master\scripts\make_help.py", line 7, in <module>
    for line in open(infile, "r") :
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa6 in position 387: illegal multibyte sequence
```
which can be solved by adding `encoding="UTF-8"`