### PR TITLE
Separate multi labeled pins for better readability

### DIFF
--- a/src/schematic/schematic_symbol.cpp
+++ b/src/schematic/schematic_symbol.cpp
@@ -9,7 +9,7 @@
 
 namespace horizon {
 
-const char *pin_name_sep = " · ";
+static const char *pin_name_sep = " · ";
 
 static const LutEnumStr<SchematicSymbol::PinDisplayMode> pdm_lut = {
         {"selected_only", SchematicSymbol::PinDisplayMode::SELECTED_ONLY},

--- a/src/schematic/schematic_symbol.cpp
+++ b/src/schematic/schematic_symbol.cpp
@@ -181,7 +181,7 @@ static std::string append_tilde(const std::string &s)
 static void append_pin_name(std::string &name, const std::string &x)
 {
     if (name.size())
-        name += " ";
+        name += " · ";
     name += append_tilde(x);
 }
 
@@ -203,12 +203,12 @@ void SchematicSymbol::apply_pin_names()
         for (auto &it_pin : symbol.pins) {
             auto pin_uuid = it_pin.first;
             for (auto &[alt_uu, pin_name] : gate->unit->pins.at(pin_uuid).names) {
-                it_pin.second.name += append_tilde(pin_name.name) + " ";
+                it_pin.second.name += append_tilde(pin_name.name) + " · ";
             }
             UUIDPath<2> path(gate->uuid, pin_uuid);
 
             if (const auto &n = get_custom_pin_name(*component, path); n.size())
-                it_pin.second.name += append_tilde(n) + " ";
+                it_pin.second.name += append_tilde(n) + " · ";
 
             it_pin.second.name += "(" + append_tilde(gate->unit->pins.at(pin_uuid).primary_name) + ")";
         }

--- a/src/schematic/schematic_symbol.cpp
+++ b/src/schematic/schematic_symbol.cpp
@@ -9,6 +9,8 @@
 
 namespace horizon {
 
+const char *pin_name_sep = " · ";
+
 static const LutEnumStr<SchematicSymbol::PinDisplayMode> pdm_lut = {
         {"selected_only", SchematicSymbol::PinDisplayMode::SELECTED_ONLY},
         {"both", SchematicSymbol::PinDisplayMode::BOTH},
@@ -181,7 +183,7 @@ static std::string append_tilde(const std::string &s)
 static void append_pin_name(std::string &name, const std::string &x)
 {
     if (name.size())
-        name += " · ";
+        name += pin_name_sep;
     name += append_tilde(x);
 }
 
@@ -203,12 +205,12 @@ void SchematicSymbol::apply_pin_names()
         for (auto &it_pin : symbol.pins) {
             auto pin_uuid = it_pin.first;
             for (auto &[alt_uu, pin_name] : gate->unit->pins.at(pin_uuid).names) {
-                it_pin.second.name += append_tilde(pin_name.name) + " · ";
+                it_pin.second.name += append_tilde(pin_name.name) + pin_name_sep;
             }
             UUIDPath<2> path(gate->uuid, pin_uuid);
 
             if (const auto &n = get_custom_pin_name(*component, path); n.size())
-                it_pin.second.name += append_tilde(n) + " · ";
+                it_pin.second.name += append_tilde(n) + pin_name_sep;
 
             it_pin.second.name += "(" + append_tilde(gate->unit->pins.at(pin_uuid).primary_name) + ")";
         }

--- a/src/util/text_data.cpp
+++ b/src/util/text_data.cpp
@@ -276,6 +276,8 @@ static unsigned int codepoint_to_hershey(gunichar c, TextData::Font font)
         case 0x3bc: // U+03BC GREEK SMALL LETTER MU
         case 0xb5:  // U+00B5 MICRO SIGN
             return 638;
+        case 0xb7: // U+00B7 MIDDLE DOT
+            return 729;
         case 0x2126: // U+2126 OHM SIGN
         case 0x3a9:  // U+03A9 GREEK CAPITAL LETTER OMEGA
             return 550;


### PR DESCRIPTION
*Initial discussion on [discourse](https://horizon-eda.discourse.group/t/separating-alternate-pin-names-with-slash/145).*

Currently, when showing multiple alternate pin names, they are separated by a single space on the schematics:

![image](https://user-images.githubusercontent.com/483682/188085915-753953e2-b9a8-4fb1-bfc0-1ce9e2cc9305.png)

This is somewhat difficult to read at times and may be mistaken in some scenarios as a single label. This PR adds unicode MIDDLE DOT as a visual separator between the labels:

![Screenshot from 2022-09-02 17-34-56](https://user-images.githubusercontent.com/483682/188086208-f47b6148-181a-438a-ae16-6070ae050df2.png)
