### PR TITLE
Fix board pdf export drawing tiny bezier arcs

### DIFF
--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -232,7 +232,6 @@ static Coordd pdf_arc_segment(PoDoFo::PdfPainter &painter, const Coordd c, const
 static void pdf_arc(PoDoFo::PdfPainter &painter, const Coordd start, const Coordd c, const Coordd end, bool cw)
 {
     const auto r = (start - c).mag();
-    const auto ctr = Coordd(c.x, c.y);
 
     // Get angles relative to the x axis
     double a0 = (start - c).angle();
@@ -257,7 +256,7 @@ static void pdf_arc(PoDoFo::PdfPainter &painter, const Coordd start, const Coord
     while (std::abs(e) > 1e-6) {
         const auto d = (cw) ? std::max(e, da) : std::min(e, da);
         const auto a = a0 + d;
-        pdf_arc_segment(painter, ctr, r, a0, a);
+        pdf_arc_segment(painter, c, r, a0, a);
         a0 = a;
         e = a1 - a0;
     }

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -252,7 +252,7 @@ static void pdf_arc(PoDoFo::PdfPainter &painter, const Coordd start, const Coord
         assert(a0 < a1);
     }
     double e = a1 - a0;
-    while (std::abs(e) > 0) {
+    while (std::abs(e) > 1e-6) {
         const auto d = (cw) ? std::max(e, da) : std::min(e, da);
         const auto a = a0 + d;
         pdf_arc_segment(painter, ctr, r, a0, a);

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -10,7 +10,7 @@
 namespace horizon {
 
 
-CanvasPDF::CanvasPDF(PoDoFo::PdfPainterMM &p, PoDoFo::PdfFont &f, const PDFExportSettings &s)
+CanvasPDF::CanvasPDF(PoDoFo::PdfPainter &p, PoDoFo::PdfFont &f, const PDFExportSettings &s)
     : Canvas::Canvas(), painter(p), font(f), settings(s), metrics(font.GetFontMetrics())
 {
     img_mode = true;
@@ -40,7 +40,7 @@ void CanvasPDF::img_line(const Coordi &p0, const Coordi &p1, const uint64_t widt
         return;
     painter.Save();
     auto w = std::max(width, settings.min_line_width);
-    painter.SetStrokeWidthMM(to_um(w));
+    painter.SetStrokeWidth(to_pt(w));
     Coordi rp0 = p0;
     Coordi rp1 = p1;
     if (tr) {
@@ -49,7 +49,7 @@ void CanvasPDF::img_line(const Coordi &p0, const Coordi &p1, const uint64_t widt
     }
     auto color = get_pdf_layer_color(layer);
     painter.SetStrokingColor(color.r, color.g, color.b);
-    painter.DrawLineMM(to_um(rp0.x), to_um(rp0.y), to_um(rp1.x), to_um(rp1.y));
+    painter.DrawLine(to_pt(rp0.x), to_pt(rp0.y), to_pt(rp1.x), to_pt(rp1.y));
     painter.Restore();
 }
 
@@ -126,7 +126,7 @@ void CanvasPDF::img_draw_text(const Coordf &p, float size, const std::string &rt
 
         painter.SetTransformationMatrix(cos(fangle), sin(fangle), -sin(fangle), cos(fangle), to_pt(pt.x), to_pt(pt.y));
         PoDoFo::PdfString pstr(reinterpret_cast<const PoDoFo::pdf_utf8 *>(line.c_str()));
-        painter.DrawTextMM(0, to_um(size) / -2, pstr);
+        painter.DrawText(0, to_pt(size) / -2, pstr);
         painter.Restore();
 
         i_line++;
@@ -141,7 +141,7 @@ void CanvasPDF::img_polygon(const Polygon &ipoly, bool tr)
     auto color = get_pdf_layer_color(ipoly.layer);
     painter.SetColor(color.r, color.g, color.b);
     painter.SetStrokingColor(color.r, color.g, color.b);
-    painter.SetStrokeWidthMM(to_um(settings.min_line_width));
+    painter.SetStrokeWidth(to_pt(settings.min_line_width));
     if (ipoly.usage == nullptr) { // regular patch
         draw_polygon(ipoly, tr);
         if (fill)
@@ -158,9 +158,9 @@ void CanvasPDF::img_polygon(const Polygon &ipoly, bool tr)
                     if (tr)
                         p = transform.transform(p);
                     if (first)
-                        painter.MoveToMM(to_um(p.x), to_um(p.y));
+                        painter.MoveTo(to_pt(p.x), to_pt(p.y));
                     else
-                        painter.LineToMM(to_um(p.x), to_um(p.y));
+                        painter.LineTo(to_pt(p.x), to_pt(p.y));
                     first = false;
                 }
                 painter.ClosePath();
@@ -183,7 +183,7 @@ void CanvasPDF::img_hole(const Hole &hole)
     auto color = get_pdf_layer_color(PDFExportSettings::HOLES_LAYER);
     painter.SetColor(color.r, color.g, color.b);
     painter.SetStrokingColor(color.r, color.g, color.b);
-    painter.SetStrokeWidthMM(to_um(settings.min_line_width));
+    painter.SetStrokeWidth(to_pt(settings.min_line_width));
 
     auto hole2 = hole;
     if (settings.set_holes_size) {
@@ -223,9 +223,7 @@ static Coordd pdf_arc_segment(PoDoFo::PdfPainter &painter, const Coordd c, const
     const auto c2 = p2.rotate(theta) * r + c;
     const auto c3 = p3.rotate(theta) * r + c;
 
-    painter.CubicBezierTo(to_um(c1.x) * CONVERSION_CONSTANT, to_um(c1.y) * CONVERSION_CONSTANT,
-                          to_um(c2.x) * CONVERSION_CONSTANT, to_um(c2.y) * CONVERSION_CONSTANT,
-                          to_um(c3.x) * CONVERSION_CONSTANT, to_um(c3.y) * CONVERSION_CONSTANT);
+    painter.CubicBezierTo(to_pt(c1.x), to_pt(c1.y), to_pt(c2.x), to_pt(c2.y), to_pt(c3.x), to_pt(c3.y));
     return c3; // end point
 }
 
@@ -276,17 +274,18 @@ void CanvasPDF::draw_polygon(const Polygon &ipoly, bool tr)
             it_next = ipoly.vertices.cbegin();
         }
         if (first) {
-            painter.MoveToMM(to_um(p.x), to_um(p.y));
+            painter.MoveTo(to_pt(p.x), to_pt(p.y));
         }
         if (it->type == Polygon::Vertex::Type::LINE) {
-            if (!first)
-                painter.LineToMM(to_um(p.x), to_um(p.y));
+            if (!first) {
+                painter.LineTo(to_pt(p.x), to_pt(p.y));
+            }
         }
         else if (it->type == Polygon::Vertex::Type::ARC) {
             Coordd end = it_next->position;
             Coordd c = it->arc_center;
             if (!first)
-                painter.LineToMM(to_um(p.x), to_um(p.y));
+                painter.LineTo(to_pt(p.x), to_pt(p.y));
 
             if (tr) {
                 c = transform.transform(c);

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -206,15 +206,15 @@ static Coordd pdf_arc_segment(PoDoFo::PdfPainter &painter, const Coordd c, const
 {
     const auto da = a0 - a1;
     assert(da != 0);
-    assert(std::abs(da) <= M_PI / 2.0 + 1e-6);
+    assert(std::abs(da) <= M_PI / 2 + 1e-6);
 
     // Shift to bisect at x axis
-    const auto theta = (a0 + a1) / 2.0;
-    const auto phi = da / 2.0;
+    const auto theta = (a0 + a1) / 2;
+    const auto phi = da / 2;
 
     // Compute points of unit circle for given delta angle
     const auto p0 = Coordd(cos(phi), sin(phi));
-    const auto p1 = Coordd((4.0 - p0.x) / 3.0, (1.0 - p0.x) * (3.0 - p0.x) / (3.0 * p0.y));
+    const auto p1 = Coordd((4 - p0.x) / 3, (1 - p0.x) * (3 - p0.x) / (3 * p0.y));
     const auto p2 = Coordd(p1.x, -p1.y);
     const auto p3 = Coordd(p0.x, -p0.y);
 
@@ -239,13 +239,13 @@ static void pdf_arc(PoDoFo::PdfPainter &painter, const Coordd start, const Coord
 
     // Circle or large arc
     if (cw && a0 <= a1) {
-        a0 += 2.0 * M_PI;
+        a0 += 2 * M_PI;
     }
     else if (!cw && a0 >= a1) {
-        a0 -= 2.0 * M_PI;
+        a0 -= 2 * M_PI;
     }
 
-    const double da = (cw) ? -M_PI / 2.0 : M_PI / 2.0;
+    const double da = (cw) ? -M_PI / 2 : M_PI / 2;
     if (cw) {
         assert(a0 > a1);
     }

--- a/src/export_pdf/canvas_pdf.hpp
+++ b/src/export_pdf/canvas_pdf.hpp
@@ -4,11 +4,6 @@
 
 namespace horizon {
 
-template <typename T> static T to_um(T x)
-{
-    return x / 1000;
-}
-
 template <typename T> static T to_pt(T x)
 {
     return x * .000002834645669291339;

--- a/src/export_pdf/canvas_pdf.hpp
+++ b/src/export_pdf/canvas_pdf.hpp
@@ -16,7 +16,7 @@ template <typename T> static T to_pt(T x)
 
 class CanvasPDF : public Canvas {
 public:
-    CanvasPDF(PoDoFo::PdfPainterMM &painter, PoDoFo::PdfFont &font, const class PDFExportSettings &settings);
+    CanvasPDF(PoDoFo::PdfPainter &painter, PoDoFo::PdfFont &font, const class PDFExportSettings &settings);
     void push() override
     {
     }
@@ -32,7 +32,7 @@ public:
     }
 
 private:
-    PoDoFo::PdfPainterMM &painter;
+    PoDoFo::PdfPainter &painter;
     PoDoFo::PdfFont &font;
     const PDFExportSettings &settings;
     const PoDoFo::PdfFontMetrics *metrics;

--- a/src/export_pdf/export_pdf.cpp
+++ b/src/export_pdf/export_pdf.cpp
@@ -112,7 +112,7 @@ public:
 
 private:
     PoDoFo::PdfStreamedDocument document;
-    PoDoFo::PdfPainterMM painter;
+    PoDoFo::PdfPainter painter;
     PoDoFo::PdfFont *font = nullptr;
     std::map<UUIDVec, PoDoFo::PdfDestination> first_pages;
     std::vector<std::tuple<UUIDVec, unsigned int, PoDoFo::PdfRect>> annotations;

--- a/src/export_pdf/export_pdf_board.cpp
+++ b/src/export_pdf/export_pdf_board.cpp
@@ -20,6 +20,7 @@ void export_pdf(const class Board &brd, const class PDFExportSettings &settings,
 
     PoDoFo::PdfStreamedDocument document(settings.output_filename.c_str());
     PoDoFo::PdfPainterMM painter;
+    painter.SetPrecision(9);
     auto info = document.GetInfo();
     info->SetCreator("horizon EDA");
     info->SetProducer("horizon EDA");

--- a/src/export_pdf/export_pdf_board.cpp
+++ b/src/export_pdf/export_pdf_board.cpp
@@ -19,7 +19,7 @@ void export_pdf(const class Board &brd, const class PDFExportSettings &settings,
     cb("Initializing", 0);
 
     PoDoFo::PdfStreamedDocument document(settings.output_filename.c_str());
-    PoDoFo::PdfPainterMM painter;
+    PoDoFo::PdfPainter painter;
     painter.SetPrecision(9);
     auto info = document.GetInfo();
     info->SetCreator("horizon EDA");

--- a/src/export_pdf/export_pdf_util.cpp
+++ b/src/export_pdf/export_pdf_util.cpp
@@ -4,7 +4,7 @@
 
 namespace horizon {
 
-void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainterMM &painter, const Picture &pic, const Placement &tr)
+void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainter &painter, const Picture &pic, const Placement &tr)
 {
     PoDoFo::PdfImage img(&doc);
     Placement pl = tr;
@@ -48,7 +48,7 @@ void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainterMM &painter, con
     const int64_t h = pic.data->height * pic.px_size;
     const auto p = Coordd(w, h) / -2;
     const double sz = pic.px_size / (1e3 / CONVERSION_CONSTANT);
-    painter.DrawImageMM(to_um(p.x), to_um(p.y), &img, sz, sz);
+    painter.DrawImage(to_pt(p.x), to_pt(p.y), &img, sz, sz);
     painter.Restore();
 }
 } // namespace horizon

--- a/src/export_pdf/export_pdf_util.hpp
+++ b/src/export_pdf/export_pdf_util.hpp
@@ -3,6 +3,6 @@
 #include "util/placement.hpp"
 
 namespace horizon {
-void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainterMM &painter, const class Picture &pic,
+void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainter &painter, const class Picture &pic,
                     const Placement &tr = Placement());
 }


### PR DESCRIPTION
I'm working on automating some stencil workflows and the current pdf export contains bezier commands with all equal points that appear to be due to float rounding/tolerances.  Edit: This occurs with rounded rect pads.

```
pdf command: c [-9.523, 7.078, -9.523, 7.078, -9.523, 7.078] is invalid
pdf command: c [-4.512, 12.089, -4.512, 12.089, -4.512, 12.089] is invalid
```

With this change I don't see any more warnings emitted.  