### PR TITLE
Fix build issue with gcc13

### DIFF
--- a/src/board/board_rules_check_util.hpp
+++ b/src/board/board_rules_check_util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include "clipper/clipper.hpp"
+#include <cstdint>
 
 namespace horizon {
 std::string get_net_name(const class Net *net);

--- a/src/logger/logger.hpp
+++ b/src/logger/logger.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <string>
 #include <tuple>
+#include <cstdint>
 
 namespace horizon {
 class Logger {


### PR DESCRIPTION
This fixes the "error: 'uint64_t' does not name a type" build error when using gcc13.