### PR TITLE
imp board: minimum diameter for holes in STEP export

### DIFF
--- a/src/board/step_export_settings.cpp
+++ b/src/board/step_export_settings.cpp
@@ -6,7 +6,7 @@ namespace horizon {
 
 STEPExportSettings::STEPExportSettings(const json &j)
     : filename(j.at("filename").get<std::string>()), prefix(j.at("prefix").get<std::string>()),
-      include_3d_models(j.at("include_3d_models"))
+      include_3d_models(j.at("include_3d_models")), min_diameter(j.value("min_diameter", 0_mm))
 {
 }
 
@@ -16,6 +16,8 @@ json STEPExportSettings::serialize() const
     j["filename"] = filename;
     j["prefix"] = prefix;
     j["include_3d_models"] = include_3d_models;
+    if (min_diameter)
+        j["min_diameter"] = min_diameter;
     return j;
 }
 

--- a/src/board/step_export_settings.hpp
+++ b/src/board/step_export_settings.hpp
@@ -18,5 +18,6 @@ public:
     std::string filename;
     std::string prefix;
     bool include_3d_models = true;
+    uint64_t min_diameter;
 };
 } // namespace horizon

--- a/src/export_step/export_step.hpp
+++ b/src/export_step/export_step.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include <string>
 #include <functional>
+#include "common/common.hpp"
 
 namespace horizon {
 void export_step(const std::string &filename, const class Board &brd, class IPool &pool, bool include_models,
                  std::function<void(const std::string &)> progress_cb, const class BoardColors *colors = nullptr,
-                 const std::string &prefix = "");
+                 const std::string &prefix = "", uint64_t min_diameter = 0_mm);
 }

--- a/src/imp/step_export.ui
+++ b/src/imp/step_export.ui
@@ -160,6 +160,37 @@
                 <property name="top_attach">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Minimum hole/via ø</property>
+                <property name="xalign">1</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="min_dia_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Exclude circular holes or vias from STEP export if they are smaller than the given diameter. Holes/vias of this size or larger are included (i.e. greater-or-equal comparison.) Has no effect on non-circular structures like slots or manually drawn outline polygons.
+
+Setting this to zero (the default) includes all holes.</property>
+                <property name="halign">start</property>
+                <property name="orientation">vertical</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/imp/step_export_window.hpp
+++ b/src/imp/step_export_window.hpp
@@ -24,6 +24,8 @@ private:
     Gtk::Button *filename_button = nullptr;
     Gtk::Button *export_button = nullptr;
     Gtk::Switch *include_3d_models_switch = nullptr;
+    Gtk::Box *min_dia_box = nullptr;
+    class SpinButtonDim *min_dia_spin_button = nullptr;
     Gtk::Entry *prefix_entry = nullptr;
 
     Gtk::TextView *log_textview = nullptr;

--- a/src/python_module/board.cpp
+++ b/src/python_module/board.cpp
@@ -286,7 +286,8 @@ static PyObject *PyBoard_export_step(PyObject *pself, PyObject *args)
         horizon::STEPExportSettings settings(settings_json);
         horizon::export_step(
                 settings.filename, self->board->board, self->board->pool, settings.include_3d_models,
-                [py_callback](const std::string &s) { callback_wrapper(py_callback, s); }, nullptr, settings.prefix);
+                [py_callback](const std::string &s) { callback_wrapper(py_callback, s); }, nullptr, settings.prefix,
+                settings.min_diameter);
     }
     catch (const py_exception &e) {
         return NULL;


### PR DESCRIPTION
Loading STEP files into some other CAD software can take quite some time depending on the complexity of the STEP file.  A board with a lot of vias takes several minutes to load into FreeCAD.  While 3D component models can be excluded (worst case even by deleting individual ones after export, like all bypass caps), editing the board itself is not that easy since it is one single 3D object.

This adds a STEP export setting to exclude all holes/vias below a given diameter.  (Generally speaking, while larger holes can be important to have in the STEP export, there's generally some cut off below which you don't care, like 1mm.)

---

I had hacked this together quite some time ago, but I just hardcoded a 0.6mm limit. Took some time today to implement proper UI for it :smile: