### PR TITLE
imp package: add bottom-up STEP projection

### DIFF
--- a/src/imp/3d/model_editor.cpp
+++ b/src/imp/3d/model_editor.cpp
@@ -187,8 +187,26 @@ ModelEditor::ModelEditor(ImpPackage &iimp, const UUID &iuu)
             box->pack_start(*place_button, false, false, 0);
         }
         {
-            auto project_button = Gtk::manage(new Gtk::Button("Project"));
-            project_button->signal_clicked().connect([this] { imp.project_model(model); });
+            auto project_button = Gtk::manage(new Gtk::MenuButton());
+            project_button->set_label("Project");
+            project_button->signal_clicked().connect(sigc::mem_fun(*this, &ModelEditor::make_current));
+            auto project_menu = Gtk::manage(new Gtk::Menu);
+            project_button->set_menu(*project_menu);
+
+            {
+                auto it = Gtk::manage(new Gtk::MenuItem("Bottom-up view"));
+                it->show();
+                project_menu->append(*it);
+                it->signal_activate().connect([this] { imp.project_model(model, ProjectionMode::BOTTOM_UP); });
+            }
+
+            {
+                auto it = Gtk::manage(new Gtk::MenuItem("Top-down view"));
+                it->show();
+                project_menu->append(*it);
+                it->signal_activate().connect([this] { imp.project_model(model, ProjectionMode::TOP_DOWN); });
+            }
+
             box->pack_start(*project_button, false, false, 0);
             widgets_insenstive_without_model.push_back(project_button);
         }

--- a/src/imp/imp_package.hpp
+++ b/src/imp/imp_package.hpp
@@ -12,6 +12,14 @@ namespace STEPImporter {
 class STEPImporter;
 }
 
+/* for projecting STEP models into package editor */
+enum class ProjectionMode {
+    /* standard top-down view / projection */
+    TOP_DOWN,
+    /* Z-mirrored / inverted bottom-up projection (NB: not a rotation) */
+    BOTTOM_UP,
+};
+
 class ImpPackage : public ImpLayer {
     class ImportCanvas3D;
     friend class ModelEditor;
@@ -67,7 +75,7 @@ private:
 
         ~ModelInfo();
     };
-    void project_model(const Package::Model &model);
+    void project_model(const Package::Model &model, ProjectionMode proj);
 
     std::map<std::string, ModelInfo> model_info;
     std::mutex model_info_mutex;


### PR DESCRIPTION
When drawing packages, while the top-down STEP projection is useful, it can in some cases be just entirely silly...  for example QFN parts in a top down view are just the package outline.

Add a bottom-up projection where you actually see useful things.

Note that this is not a rotation, it's a reversal of the Z axis.  This doesn't seem to be possible in gp_Ax2 since it turns around the handedness of the coordinate system.  Hence some transform shenanigans on this.

Bonus points for gp_Trsf trying to be clever and converting the (1,1,-1) matrix into a "(-1,-1,1) + scale -1" matrix, the scale part of which is then later ignored by default in HLRAlgo_Projector...  so suddenly it's an XY flip :'(

---

I feel like OpenCASCADE made this much harder than necessary :cry: … took a bunch of whacking things with a hammer to get this going.

For reference here's top-down and bottom-up for a USB connector, with the STEP model moved to the side to make it more obvious:

Top down (only option before this PR)

![top down](https://github.com/horizon-eda/horizon/assets/1715611/7553832f-1b8e-46a4-b5de-10467d5a5024)

Bottom up (added by this PR)

![bottom up](https://github.com/horizon-eda/horizon/assets/1715611/287c1752-58fa-4374-bd8b-e1fc65d216e7)