### PR TITLE
WIP: imp board: exclude packages from STEP export

### DIFF
--- a/src/board/step_export_settings.cpp
+++ b/src/board/step_export_settings.cpp
@@ -6,7 +6,7 @@ namespace horizon {
 
 STEPExportSettings::STEPExportSettings(const json &j)
     : filename(j.at("filename").get<std::string>()), prefix(j.at("prefix").get<std::string>()),
-      include_3d_models(j.at("include_3d_models"))
+      include_3d_models(j.at("include_3d_models")), min_diameter(j.value("min_diameter", 0_mm))
 {
 }
 
@@ -16,6 +16,8 @@ json STEPExportSettings::serialize() const
     j["filename"] = filename;
     j["prefix"] = prefix;
     j["include_3d_models"] = include_3d_models;
+    if (min_diameter)
+        j["min_diameter"] = min_diameter;
     return j;
 }
 

--- a/src/board/step_export_settings.cpp
+++ b/src/board/step_export_settings.cpp
@@ -8,6 +8,14 @@ STEPExportSettings::STEPExportSettings(const json &j)
     : filename(j.at("filename").get<std::string>()), prefix(j.at("prefix").get<std::string>()),
       include_3d_models(j.at("include_3d_models")), min_diameter(j.value("min_diameter", 0_mm))
 {
+    auto excllist = j.value("pkgs_excluded", json::array());
+
+    for (const auto &excluuid : excllist) {
+        if (!excluuid.is_string())
+            continue;
+
+        pkgs_excluded.emplace(excluuid.get<std::string>());
+    }
 }
 
 json STEPExportSettings::serialize() const
@@ -18,6 +26,15 @@ json STEPExportSettings::serialize() const
     j["include_3d_models"] = include_3d_models;
     if (min_diameter)
         j["min_diameter"] = min_diameter;
+    if (pkgs_excluded.size()) {
+        auto excllist = json::array();
+
+        for (const auto &uuid : pkgs_excluded) {
+            excllist.push_back(uuid);
+        }
+
+        j["pkgs_excluded"] = excllist;
+    }
     return j;
 }
 

--- a/src/board/step_export_settings.hpp
+++ b/src/board/step_export_settings.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <set>
 #include "common/common.hpp"
 #include "common/lut.hpp"
 #include "nlohmann/json_fwd.hpp"
@@ -19,5 +20,6 @@ public:
     std::string prefix;
     bool include_3d_models = true;
     uint64_t min_diameter;
+    std::set<UUID> pkgs_excluded;
 };
 } // namespace horizon

--- a/src/board/step_export_settings.hpp
+++ b/src/board/step_export_settings.hpp
@@ -18,5 +18,6 @@ public:
     std::string filename;
     std::string prefix;
     bool include_3d_models = true;
+    uint64_t min_diameter;
 };
 } // namespace horizon

--- a/src/export_step/export_step.cpp
+++ b/src/export_step/export_step.cpp
@@ -407,7 +407,7 @@ static bool getModelLabel(const std::string &aFileName, TDF_Label &aLabel, Handl
 
 void export_step(const std::string &filename, const Board &brd, class IPool &pool, bool include_models,
                  std::function<void(const std::string &)> progress_cb, const BoardColors *colors,
-                 const std::string &prefix, uint64_t min_diameter)
+                 const std::string &prefix, uint64_t min_diameter, std::set<UUID> *pkgs_excluded)
 {
     try {
         auto app = XCAFApp_Application::GetApplication();
@@ -501,6 +501,9 @@ void export_step(const std::string &filename, const Board &brd, class IPool &poo
             pkgs.reserve(brd.packages.size());
             for (const auto &[uuid, package] : brd.packages) {
                 if (package.component && package.component->nopopulate) {
+                    continue;
+                }
+                if (pkgs_excluded && (pkgs_excluded->find(package.package.uuid) != pkgs_excluded->end())) {
                     continue;
                 }
                 pkgs.push_back(&package);

--- a/src/export_step/export_step.hpp
+++ b/src/export_step/export_step.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include <string>
 #include <functional>
+#include "common/common.hpp"
 
 namespace horizon {
 void export_step(const std::string &filename, const class Board &brd, class IPool &pool, bool include_models,
                  std::function<void(const std::string &)> progress_cb, const class BoardColors *colors = nullptr,
-                 const std::string &prefix = "");
+                 const std::string &prefix = "", uint64_t min_diameter = 0_mm);
 }

--- a/src/export_step/export_step.hpp
+++ b/src/export_step/export_step.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include <string>
 #include <functional>
+#include <set>
+#include "util/uuid.hpp"
 #include "common/common.hpp"
 
 namespace horizon {
 void export_step(const std::string &filename, const class Board &brd, class IPool &pool, bool include_models,
                  std::function<void(const std::string &)> progress_cb, const class BoardColors *colors = nullptr,
-                 const std::string &prefix = "", uint64_t min_diameter = 0_mm);
+                 const std::string &prefix = "", uint64_t min_diameter = 0_mm, std::set<UUID> *pkgs_excluded = nullptr);
 }

--- a/src/imp/step_export.ui
+++ b/src/imp/step_export.ui
@@ -160,6 +160,37 @@
                 <property name="top_attach">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Minimum hole/via ø</property>
+                <property name="xalign">1</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="min_dia_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Exclude circular holes or vias from STEP export if they are smaller than the given diameter. Holes/vias of this size or larger are included (i.e. greater-or-equal comparison.) Has no effect on non-circular structures like slots or manually drawn outline polygons.
+
+Setting this to zero (the default) includes all holes.</property>
+                <property name="halign">start</property>
+                <property name="orientation">vertical</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/imp/step_export.ui
+++ b/src/imp/step_export.ui
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-next-symbolic</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-previous-symbolic</property>
+  </object>
   <object class="GtkWindow" id="window">
     <property name="can_focus">False</property>
     <property name="default_height">400</property>
@@ -45,6 +55,7 @@
         <property name="orientation">vertical</property>
         <property name="spacing">20</property>
         <child>
+          <!-- n-columns=3 n-rows=4 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -80,7 +91,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -93,7 +104,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -173,7 +184,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
@@ -188,7 +199,7 @@ Setting this to zero (the default) includes all holes.</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
           </object>
@@ -196,6 +207,153 @@ Setting this to zero (the default) includes all holes.</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <!-- n-columns=3 n-rows=2 -->
+          <object class="GtkGrid" id="grid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_spacing">10</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">5</property>
+                <property name="vexpand">False</property>
+                <property name="label" translatable="yes">Included packages</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">5</property>
+                <property name="label" translatable="yes">Excluded packages</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="margin_top">20</property>
+                <property name="margin_bottom">20</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkButton" id="pkg_excl_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="image">image1</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="pkg_incl_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="margin_bottom">5</property>
+                    <property name="image">image2</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="pkgs_included_tv">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="search-column">0</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection">
+                        <property name="mode">multiple</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="pkgs_excluded_tv">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">False</property>
+                    <property name="search-column">0</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection">
+                        <property name="mode">multiple</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>

--- a/src/imp/step_export_window.hpp
+++ b/src/imp/step_export_window.hpp
@@ -2,6 +2,7 @@
 #include <gtkmm.h>
 #include <array>
 #include <set>
+#include "util/uuid.hpp"
 #include "util/export_file_chooser.hpp"
 #include "util/changeable.hpp"
 
@@ -27,6 +28,28 @@ private:
     Gtk::Box *min_dia_box = nullptr;
     class SpinButtonDim *min_dia_spin_button = nullptr;
     Gtk::Entry *prefix_entry = nullptr;
+    Gtk::Button *pkg_incl_button = nullptr;
+    Gtk::Button *pkg_excl_button = nullptr;
+    Gtk::TreeView *pkgs_included_tv = nullptr;
+    Gtk::TreeView *pkgs_excluded_tv = nullptr;
+
+    class ListColumns : public Gtk::TreeModelColumnRecord {
+    public:
+        ListColumns()
+        {
+            Gtk::TreeModelColumnRecord::add(pkg_name);
+            Gtk::TreeModelColumnRecord::add(pkg_count);
+            Gtk::TreeModelColumnRecord::add(uuid);
+        }
+        Gtk::TreeModelColumn<Glib::ustring> pkg_name;
+        Gtk::TreeModelColumn<unsigned int> pkg_count;
+        Gtk::TreeModelColumn<UUID> uuid;
+    };
+    ListColumns list_columns;
+
+    Glib::RefPtr<Gtk::ListStore> pkgs_store;
+    Glib::RefPtr<Gtk::TreeModelFilter> pkgs_included;
+    Glib::RefPtr<Gtk::TreeModelFilter> pkgs_excluded;
 
     Gtk::TextView *log_textview = nullptr;
     Gtk::Spinner *spinner = nullptr;
@@ -45,6 +68,10 @@ private:
     std::mutex msg_queue_mutex;
     std::deque<std::string> msg_queue;
     bool export_running = false;
+
+    void pkgs_fill();
+    void update_pkg_incl_excl_sensitivity();
+    void pkg_incl_excl(bool incl);
 
     void set_is_busy(bool v);
 

--- a/src/imp/step_export_window.hpp
+++ b/src/imp/step_export_window.hpp
@@ -24,6 +24,8 @@ private:
     Gtk::Button *filename_button = nullptr;
     Gtk::Button *export_button = nullptr;
     Gtk::Switch *include_3d_models_switch = nullptr;
+    Gtk::Box *min_dia_box = nullptr;
+    class SpinButtonDim *min_dia_spin_button = nullptr;
     Gtk::Entry *prefix_entry = nullptr;
 
     Gtk::TextView *log_textview = nullptr;

--- a/src/python_module/board.cpp
+++ b/src/python_module/board.cpp
@@ -286,7 +286,8 @@ static PyObject *PyBoard_export_step(PyObject *pself, PyObject *args)
         horizon::STEPExportSettings settings(settings_json);
         horizon::export_step(
                 settings.filename, self->board->board, self->board->pool, settings.include_3d_models,
-                [py_callback](const std::string &s) { callback_wrapper(py_callback, s); }, nullptr, settings.prefix);
+                [py_callback](const std::string &s) { callback_wrapper(py_callback, s); }, nullptr, settings.prefix,
+                settings.min_diameter);
     }
     catch (const py_exception &e) {
         return NULL;


### PR DESCRIPTION
WORK IN PROGRESS / DRAFT.

As discussed in #720, a way to exclude some packages from STEP export.

*after* coding this I realized it doesn't need the 2 treeviews with ← / → buttons… one treeview with checkboxes would be perfectly fine. *after* is always when you realize these things, I guess.

Out of time for now, not sure when I can redo it with checkboxes instead of 2 treeviews. Leaving it here as a draft for now :smile: