### PR TITLE
Make MPN on the Orderable MPNs on BOM export selectable

### DIFF
--- a/src/imp/bom_export_window.cpp
+++ b/src/imp/bom_export_window.cpp
@@ -301,6 +301,7 @@ public:
         parent.sg_manufacturer->add_widget(*la_manufacturer);
 
         auto la_MPN = Gtk::manage(new Gtk::Label(part.get_MPN()));
+        la_MPN->set_selectable(true);
         la_MPN->set_xalign(0);
         la_MPN->show();
         pack_start(*la_MPN, false, false, 0);


### PR DESCRIPTION
This is usually the place where one searches part distributor website for MPN to pick the right orderable MPN, so being able to copy the MPN is a time saver.

![Screenshot from 2023-07-24 15-07-45](https://github.com/horizon-eda/horizon/assets/483682/09b8342c-fac6-43e6-9c11-5c6df310d1a5)
