### PR TITLE
Check for unused junctions in symbol editor 

### DIFF
--- a/src/symbol/symbol_rules_check.cpp
+++ b/src/symbol/symbol_rules_check.cpp
@@ -211,6 +211,19 @@ RulesCheckResult SymbolRules::check_symbol(const Symbol &sym) const
         }
     }
 
+    {
+        // Check unused junctions
+        for (const auto &[uu, junction] : sym.junctions) {
+            if (junction.connected_lines.size() == 0 && junction.connected_arcs.size() == 0) {
+                r.errors.emplace_back(RulesCheckErrorLevel::WARN);
+                auto &x = r.errors.back();
+                x.comment = "Junction has no connections";
+                x.has_location = true;
+                x.location = junction.position;
+            }
+        }
+    }
+
     r.update();
     return r;
 }


### PR DESCRIPTION
Hopefully that is all that's needed. Seems to work.

![horizon-junction-connections-check](https://github.com/horizon-eda/horizon/assets/380158/a561c1c7-5870-433c-a255-7764aa1a1203)

Fixes #730