### PR TITLE
Guess pin number name direction in unit editor

### DIFF
--- a/src/pool-prj-mgr/pool-mgr/editors/unit_editor.hpp
+++ b/src/pool-prj-mgr/pool-mgr/editors/unit_editor.hpp
@@ -46,6 +46,9 @@ private:
     void sort();
     void handle_activate(class PinEditor *ed);
     void update_pin_count();
+    std::string guess_pin_name(const Pin *last_pin);
+    Pin *pin_at_index(int index);
+    int get_pin_index(const Pin *pin);
 
     SortHelper sort_helper;
     void load();


### PR DESCRIPTION
This guesses the direction to increment the name when adding the next pin, which depending on the sort can save time. If the previous 2 pins have a delta of -1 it decrements instead of incrementing (until 0).

![image](https://github.com/horizon-eda/horizon/assets/380158/314a1125-b936-44a6-b1c1-a6dded6b2a54)
