### PR TITLE
Fix crash when pns is walking around arcs

### DIFF
--- a/3rd_party/router/kimath/include/geometry/shape.h
+++ b/3rd_party/router/kimath/include/geometry/shape.h
@@ -96,6 +96,11 @@ public:
         return m_type;
     }
 
+    wxString TypeName() const
+    {
+        return SHAPE_TYPE_asString( m_type );
+    }
+
     virtual bool HasIndexableSubshapes() const
     {
         return false;

--- a/3rd_party/router/kimath/src/geometry/shape_collisions.cpp
+++ b/3rd_party/router/kimath/src/geometry/shape_collisions.cpp
@@ -290,8 +290,8 @@ static inline bool Collide( const SHAPE_LINE_CHAIN_BASE& aA, const SHAPE_LINE_CH
                             int aClearance, int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     int closest_dist = INT_MAX;
     VECTOR2I nearest;
@@ -372,8 +372,8 @@ static inline bool Collide( const SHAPE_RECT& aA, const SHAPE_LINE_CHAIN_BASE& a
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     int closest_dist = INT_MAX;
     VECTOR2I nearest;
@@ -429,8 +429,8 @@ static inline bool Collide( const SHAPE_RECT& aA, const SHAPE_SEGMENT& aB, int a
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     bool rv = aA.Collide( aB.GetSeg(), aClearance + aB.GetWidth() / 2, aActual, aLocation );
 
@@ -445,8 +445,8 @@ static inline bool Collide( const SHAPE_SEGMENT& aA, const SHAPE_SEGMENT& aB, in
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     bool rv = aA.Collide( aB.GetSeg(), aClearance + aB.GetWidth() / 2, aActual, aLocation );
 
@@ -461,8 +461,8 @@ static inline bool Collide( const SHAPE_LINE_CHAIN_BASE& aA, const SHAPE_SEGMENT
                             int aClearance, int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     bool rv = aA.Collide( aB.GetSeg(), aClearance + aB.GetWidth() / 2, aActual, aLocation );
 
@@ -484,8 +484,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_RECT& aB, int aClea
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     const SHAPE_LINE_CHAIN lc( aA );
 
@@ -502,8 +502,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_CIRCLE& aB, int aCl
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     const SHAPE_LINE_CHAIN lc( aA );
 
@@ -520,8 +520,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_LINE_CHAIN& aB, int
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     int      closest_dist = INT_MAX;
     VECTOR2I nearest;
@@ -592,8 +592,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_SEGMENT& aB, int aC
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     const SHAPE_LINE_CHAIN lc( aA );
 
@@ -610,8 +610,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_LINE_CHAIN_BASE& aB
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     int      closest_dist = INT_MAX;
     VECTOR2I nearest;
@@ -667,8 +667,8 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_ARC& aB, int aClear
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
     wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
-                                           aA.Type(),
-                                           aB.Type() ) );
+                                           aA.TypeName(),
+                                           aB.TypeName() ) );
 
     SEG mediatrix( aA.GetCenter(), aB.GetCenter() );
 

--- a/3rd_party/router/kimath/src/geometry/shape_collisions.cpp
+++ b/3rd_party/router/kimath/src/geometry/shape_collisions.cpp
@@ -501,9 +501,10 @@ static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_RECT& aB, int aClea
 static inline bool Collide( const SHAPE_ARC& aA, const SHAPE_CIRCLE& aB, int aClearance,
                             int* aActual, VECTOR2I* aLocation, VECTOR2I* aMTV )
 {
-    wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
+    // https://gitlab.com/kicad/code/kicad/-/commit/df9cf0a0c39ed99527b0c04e3892e8dd7ed603e7
+    /* wxASSERT_MSG( !aMTV, wxString::Format( wxT( "MTV not implemented for %s : %s collisions" ),
                                            aA.TypeName(),
-                                           aB.TypeName() ) );
+                                           aB.TypeName() ) ); */
 
     const SHAPE_LINE_CHAIN lc( aA );
 


### PR DESCRIPTION
When routing a track in walkaround mode, horizon crashes when the routed track collides with an arc. This due to the assert statement:

`horizon-imp: ../3rd_party/router/kimath/src/geometry/shape_collisions.cpp:504: bool Collide(const SHAPE_ARC&, const SHAPE_CIRCLE&, int, int*, VECTOR2I*, VECTOR2I*): Assertion (!aMTV) failed.`

In KiCad this assert statement was removed to fix this problem, so i think it should be ok to do the same here.

https://gitlab.com/kicad/code/kicad/-/commit/df9cf0a0c39ed99527b0c04e3892e8dd7ed603e7

Would be nicer to port the entire KiCad Router 7.0.7 or at least 6.0.11 to horizon, but i tried and then decided it is to much trouble for just a small fix.  