### PR TITLE
odb export: include mounting type atrribute of components

### DIFF
--- a/src/export_odb/attributes.hpp
+++ b/src/export_odb/attributes.hpp
@@ -50,10 +50,12 @@ template <typename T> struct text_attribute {
 template <typename T> struct is_feature : std::false_type {};
 template <typename T> struct is_net : std::false_type {};
 template <typename T> struct is_pkg : std::false_type {};
+template <typename T> struct is_comp : std::false_type {};
 
 template <class T> inline constexpr bool is_feature_v = is_feature<T>::value;
 template <class T> inline constexpr bool is_net_v = is_net<T>::value;
 template <class T> inline constexpr bool is_pkg_v = is_pkg<T>::value;
+template <class T> inline constexpr bool is_comp_v = is_comp<T>::value;
 
 #define ATTR_IS_FEATURE(a)                                                                                             \
     template <> struct is_feature<a> : std::true_type {};
@@ -63,6 +65,9 @@ template <class T> inline constexpr bool is_pkg_v = is_pkg<T>::value;
 
 #define ATTR_IS_PKG(a)                                                                                                 \
     template <> struct is_pkg<a> : std::true_type {};
+
+#define ATTR_IS_COMP(a)                                                                                                \
+    template <> struct is_comp<a> : std::true_type {};
 
 enum class drill { PLATED, NON_PLATED, VIA };
 ATTR_NAME(drill)
@@ -74,6 +79,10 @@ ATTR_NAME(primary_side)
 enum class pad_usage { TOEPRINT, VIA, G_FIDUCIAL, L_FIDUCIAL, TOOLING_HOLE };
 ATTR_NAME(pad_usage)
 ATTR_IS_FEATURE(pad_usage)
+
+enum class comp_mount_type { OTHER, SMT, THMT, PRESSFIT };
+ATTR_NAME(comp_mount_type)
+ATTR_IS_COMP(comp_mount_type)
 
 MAKE_FLOAT_ATTR(drc_max_height, 3)
 ATTR_IS_FEATURE(drc_max_height)

--- a/src/export_odb/components.hpp
+++ b/src/export_odb/components.hpp
@@ -24,6 +24,8 @@ public:
 
     class Component : public RecordWithAttributes {
     public:
+        template <typename T> using check_type = attribute::is_comp<T>;
+
         Component(unsigned int i, unsigned int r) : index(i), pkg_ref(r)
         {
         }

--- a/src/export_odb/db.cpp
+++ b/src/export_odb/db.cpp
@@ -64,6 +64,8 @@ Components::Component &Step::add_component(const BoardPackage &bpkg)
     comp.comp_name = make_legal_name(bpkg.component->refdes);
     comp.part_name =
             make_legal_name(bpkg.component->part ? bpkg.component->part->get_MPN() : bpkg.component->entity->name);
+    if (pkg.mtype)
+        comps.add_attribute(comp, pkg.mtype.value());
 
     return comp;
 }

--- a/src/export_odb/eda_data.cpp
+++ b/src/export_odb/eda_data.cpp
@@ -275,6 +275,7 @@ EDAData::Pin &EDAData::Package::add_pin(const horizon::Pad &pad)
         pin.type = Pin::Type::THROUGH_HOLE;
         pin.mtype = Pin::MountType::THROUGH_HOLE;
         pin.etype = Pin::ElectricalType::ELECTRICAL;
+        mtype = attribute::comp_mount_type::THMT;
         break;
 
     case Padstack::Type::TOP:
@@ -282,12 +283,15 @@ EDAData::Pin &EDAData::Package::add_pin(const horizon::Pad &pad)
         pin.type = Pin::Type::SURFACE;
         pin.mtype = Pin::MountType::SMT;
         pin.etype = Pin::ElectricalType::ELECTRICAL;
+        if (!mtype)
+            mtype = attribute::comp_mount_type::SMT;
         break;
 
     case Padstack::Type::MECHANICAL:
         pin.type = Pin::Type::THROUGH_HOLE;
         pin.mtype = Pin::MountType::THROUGH_HOLE;
         pin.etype = Pin::ElectricalType::MECHANICAL;
+        mtype = attribute::comp_mount_type::THMT;
         break;
 
     default:;

--- a/src/export_odb/eda_data.hpp
+++ b/src/export_odb/eda_data.hpp
@@ -224,6 +224,8 @@ public:
         uint64_t pitch;
         int64_t xmin, ymin, xmax, ymax;
 
+        std::optional<attribute::comp_mount_type> mtype = std::nullopt;
+
         std::list<std::unique_ptr<Outline>> outline;
 
         Pin &add_pin(const horizon::Pad &pad);


### PR DESCRIPTION
Some manufacturers (in particular Aisler) require component mounting information in the ODB++ output to do assembly.