### PR TITLE
add support for OpenBSD

### DIFF
--- a/src/pool-prj-mgr/pool-prj-mgr-main.cpp
+++ b/src/pool-prj-mgr/pool-prj-mgr-main.cpp
@@ -11,6 +11,11 @@
 
 int main(int argc, char *argv[])
 {
+#ifdef __OpenBSD__
+    extern char *argv0;
+    argv0 = argv[0];
+#endif
+
 #ifdef G_OS_WIN32
     SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
 #endif


### PR DESCRIPTION
since OpenBSD has no API to get the path that was used to create the current process, the get_exe_dir() implementation makes use of argv[0] and the PATH environment variable.