### PR TITLE
Change default via rule drill size to 0.3mm

### DIFF
--- a/src/board/rule_via.cpp
+++ b/src/board/rule_via.cpp
@@ -7,7 +7,7 @@ namespace horizon {
 RuleVia::RuleVia(const UUID &uu) : Rule(uu)
 {
     parameter_set[ParameterID::VIA_DIAMETER] = .5_mm;
-    parameter_set[ParameterID::HOLE_DIAMETER] = .2_mm;
+    parameter_set[ParameterID::HOLE_DIAMETER] = .3_mm;
 }
 
 RuleVia::RuleVia(const UUID &uu, const json &j, const RuleImportMap &import_map)


### PR DESCRIPTION
I think 0.3mm might be a better default?

Locally I can only specify less than a 10 mil (0.254mm) drill for 6 layer+ boards.  JLCPCB seems to ignore a this and use 0.3mm anyways. PCBWay gives a very expensive price (>10x normal). 
