### PR TITLE
ensure XDG_CACHE_HOME exists

### DIFF
--- a/src/imp/imp_main.cpp
+++ b/src/imp/imp_main.cpp
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     auto pool_base_path = Glib::getenv("HORIZON_POOL");
     horizon::setup_locale();
 
-    horizon::create_config_dir();
+    horizon::create_cache_and_config_dir();
 
     std::unique_ptr<horizon::ImpBase> imp = nullptr;
     if (mode_sch) {

--- a/src/pool-prj-mgr/pool-prj-mgr-main.cpp
+++ b/src/pool-prj-mgr/pool-prj-mgr-main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
     gtk_disable_setlocale();
     auto application = horizon::PoolProjectManagerApplication::create();
     horizon::setup_locale();
-    horizon::create_config_dir();
+    horizon::create_cache_and_config_dir();
     horizon::PoolManager::init();
     horizon::AutomaticPreferences::get();
     horizon::StockInfoProvider::init_db();

--- a/src/pr-review/pr-review.cpp
+++ b/src/pr-review/pr-review.cpp
@@ -1170,7 +1170,7 @@ int main(int c_argc, char *c_argv[])
     Gio::init();
     PoolManager::init();
     git_libgit2_init();
-    create_config_dir();
+    create_cache_and_config_dir();
 
     Reviewer rev;
     return rev.main(c_argc, c_argv);

--- a/src/python_module/horizonmodule.cpp
+++ b/src/python_module/horizonmodule.cpp
@@ -34,7 +34,7 @@ PyMODINIT_FUNC PyInit_horizon(void)
     Gio::init();
     horizon::PoolManager::init();
     horizon::setup_locale();
-    horizon::create_config_dir();
+    horizon::create_cache_and_config_dir();
 
     if (PyType_Ready(&ProjectType) < 0)
         return NULL;

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -2,7 +2,9 @@
 #include <fstream>
 #include <giomm.h>
 #include <glibmm/miscutils.h>
+#include <glib/gfileutils.h>
 #include <glib/gstdio.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #ifdef G_OS_WIN32
 #include <windows.h>
@@ -215,11 +217,12 @@ std::string get_config_dir()
     return Glib::build_filename(Glib::get_user_config_dir(), "horizon");
 }
 
-void create_config_dir()
+void create_cache_and_config_dir()
 {
+    auto cache_dir = Glib::get_user_cache_dir();
+    g_mkdir_with_parents(cache_dir.c_str(), S_IRWXU);
     auto config_dir = get_config_dir();
-    if (!Glib::file_test(config_dir, Glib::FILE_TEST_EXISTS))
-        Gio::File::create_for_path(config_dir)->make_directory_with_parents();
+    g_mkdir_with_parents(config_dir.c_str(), S_IRWXU);
 }
 
 void replace_backslash(std::string &path)

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -52,7 +52,7 @@ bool endswith(const std::string &haystack, const std::string &needle);
 
 int strcmp_natural(const std::string &a, const std::string &b);
 int strcmp_natural(const char *a, const char *b);
-void create_config_dir();
+void create_cache_and_config_dir();
 std::string get_config_dir();
 
 void replace_backslash(std::string &path);


### PR DESCRIPTION
while packaging Horizon EDA for OpenBSD i noticed, that when launched from a freshly created user account it fails with
```
libc++abi: terminating due to uncaught exception of type horizon::SQLite::Error: unable to open database file
Abort trap (core dumped)
```
that happens cause XDG_CACHE_HOME  (`~/.cache` in this case) does not exist in the home directory yet.

this change ensures it exists and also temporarily changes umask to ensure permissions according to XDG Base Directory Specification.