### PR TITLE
Allow packages to fix parameters

### DIFF
--- a/scripts/app_versions.yml
+++ b/scripts/app_versions.yml
@@ -30,6 +30,8 @@ versions:
     6: add net ties
     7: keep nets on unconnected labels
     8: add BOM export customisation
+  package:
+    1: package-defined solder mask & paste parameters override board parameters
   project:
     1: replace pool cache with project pool
     2: add hierarchy

--- a/src/core/core_package.cpp
+++ b/src/core/core_package.cpp
@@ -13,7 +13,8 @@ CorePackage::CorePackage(const std::string &filename, IPool &pool)
     : Core(pool, nullptr), package(Package::new_from_file(filename, pool)), m_filename(filename),
       m_pictures_dir(Glib::build_filename(Glib::path_get_dirname(filename), "pictures")), rules(package.rules),
       grid_settings(package.grid_settings), parameter_program_code(package.parameter_program.get_code()),
-      parameter_set(package.parameter_set), models(package.models), default_model(package.default_model)
+      parameter_set(package.parameter_set), parameters_fixed(package.parameters_fixed), models(package.models),
+      default_model(package.default_model)
 {
     package.load_pictures(m_pictures_dir);
     rebuild("init");
@@ -261,6 +262,7 @@ const std::string &CorePackage::get_filename() const
 void CorePackage::save(const std::string &suffix)
 {
     package.parameter_set = parameter_set;
+    package.parameters_fixed = parameters_fixed;
     package.parameter_program.set_code(parameter_program_code);
     package.models = models;
     package.default_model = default_model;

--- a/src/core/core_package.hpp
+++ b/src/core/core_package.hpp
@@ -81,6 +81,7 @@ private:
 public:
     std::string parameter_program_code;
     ParameterSet parameter_set;
+    std::set<ParameterID> parameters_fixed;
 
     std::map<UUID, Package::Model> models;
     UUID default_model;

--- a/src/imp/imp_package.hpp
+++ b/src/imp/imp_package.hpp
@@ -55,6 +55,13 @@ protected:
 
     std::vector<std::string> get_view_hints() override;
 
+    unsigned int get_required_version() const override;
+
+    bool uses_dynamic_version() const override
+    {
+        return true;
+    }
+
 private:
     void canvas_update() override;
     CorePackage core_package;

--- a/src/imp/rules/rule_editor_thermals.cpp
+++ b/src/imp/rules/rule_editor_thermals.cpp
@@ -170,7 +170,7 @@ void RuleEditorThermals::populate()
             b2->join_group(*b1);
             box->pack_start(*b2, true, true, 0);
 
-            auto b3 = Gtk::manage(new Gtk::RadioButton("Thermal rlief"));
+            auto b3 = Gtk::manage(new Gtk::RadioButton("Thermal relief"));
             b3->set_mode(false);
             b3->join_group(*b1);
             box->pack_start(*b3, true, true, 0);

--- a/src/package/pad.cpp
+++ b/src/package/pad.cpp
@@ -11,6 +11,12 @@ Pad::Pad(const UUID &uu, const json &j, IPool &pool)
     if (j.count("parameter_set")) {
         parameter_set = parameter_set_from_json(j.at("parameter_set"));
     }
+    if (j.count("parameters_fixed")) {
+        const json &o = j["parameters_fixed"];
+        for (const auto &value : o) {
+            parameters_fixed.insert(parameter_id_from_string(value.get<std::string>()));
+        }
+    }
 }
 Pad::Pad(const UUID &uu, std::shared_ptr<const Padstack> ps) : uuid(uu), pool_padstack(ps), padstack(*ps)
 {
@@ -23,6 +29,9 @@ json Pad::serialize() const
     j["placement"] = placement.serialize();
     j["name"] = name;
     j["parameter_set"] = parameter_set_serialize(parameter_set);
+    for (const auto &it : parameters_fixed) {
+        j["parameters_fixed"].push_back(parameter_id_to_string(it));
+    }
 
     return j;
 }

--- a/src/package/pad.hpp
+++ b/src/package/pad.hpp
@@ -19,6 +19,7 @@ public:
     Placement placement;
     std::string name;
     ParameterSet parameter_set;
+    std::set<ParameterID> parameters_fixed;
 
     uuid_ptr<class Net> net = nullptr;
     bool is_nc = false;

--- a/src/parameter/set.cpp
+++ b/src/parameter/set.cpp
@@ -66,4 +66,22 @@ ParameterSet parameter_set_from_json(const json &j)
     }
     return ps;
 }
+
+
+void copy_param(ParameterSet &dest, const ParameterSet &src, const std::set<ParameterID> &parameters_fixed,
+                ParameterID id)
+{
+    if (src.count(id) && !parameters_fixed.count(id)) {
+        dest[id] = src.at(id);
+    }
+}
+
+void copy_param(ParameterSet &dest, const ParameterSet &src, const std::set<ParameterID> &parameters_fixed,
+                const std::set<ParameterID> &ids)
+{
+    for (const auto id : ids) {
+        copy_param(dest, src, parameters_fixed, id);
+    }
+}
+
 } // namespace horizon

--- a/src/parameter/set.hpp
+++ b/src/parameter/set.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "nlohmann/json_fwd.hpp"
 #include <map>
+#include <set>
 #include <string>
 
 namespace horizon {
@@ -31,4 +32,8 @@ ParameterSet parameter_set_from_json(const json &j);
 ParameterID parameter_id_from_string(const std::string &s);
 const std::string &parameter_id_to_string(ParameterID id);
 const std::string &parameter_id_to_name(ParameterID id);
+void copy_param(ParameterSet &dest, const ParameterSet &src, const std::set<ParameterID> &parameters_fixed,
+                ParameterID id);
+void copy_param(ParameterSet &dest, const ParameterSet &src, const std::set<ParameterID> &parameters_fixed,
+                const std::set<ParameterID> &ids);
 } // namespace horizon

--- a/src/pool/package.hpp
+++ b/src/pool/package.hpp
@@ -104,6 +104,7 @@ public:
     std::map<UUID, Picture> pictures;
 
     ParameterSet parameter_set;
+    std::set<ParameterID> parameters_fixed;
     MyParameterProgram parameter_program;
     PackageRules rules;
     GridSettings grid_settings;
@@ -125,6 +126,8 @@ public:
 
     std::vector<Pad *> get_pads_sorted();
     std::vector<const Pad *> get_pads_sorted() const;
+
+    unsigned int get_required_version() const;
 
 private:
     void update_refs();


### PR DESCRIPTION
This change allows packages and pads to define fixed parameters, which cannot be overwritten by a board's parameter rule. This can be useful in a number of situations, such as a package that wants to define a courtyard excess based on IPC density level, or has specific solder and paste mask settings that are recommended by the manufacturer. While these results can also be obtained by manually defining the courtyard boundary or a adding a shape on the mask layer, parametric definitions are much nicer.

This change bumps the pool version to 1, and adds `parameters_fixed` as a field in packages and pads. When the board pushes its parameter rule to packages via `Package::apply_parameter_set`, the parameter ID is checked against the set of fixed parameters. When both a pad and package fix the same parameter, the pad's value will take precedence.

In the parameter set editor UI, the option to fix a parameter is an additional button that appears with the pin icon, which is similarly used in many other programs. When multiple pads are selected in the parameter editor, using the `All` button will copy the fixed field to all pads, and clicking the `All` button on a fixed parameter will also copy it to all pads.

While fixed parameters could conceptually apply to padstacks, padstacks also allow required parameters that must be defined by a pad. Having a parameter that is both fixed (at the padstack level) and required of pads using it would be somewhat contradictory, so padstacks cannot define fixed parameters.