### PR TITLE
Highlight board editor unplaced package list selection in schematic

### DIFF
--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -791,6 +791,18 @@ void ImpBoard::construct()
         }
         this->tool_begin(ToolID::MAP_PACKAGE, true, components);
     });
+    unplaced_box->signal_selected().connect([this](const auto &items) {
+        json j;
+        j["op"] = "board-select";
+        j["selection"] = nullptr;
+        for (const auto &it : items) {
+            json k;
+            k["type"] = static_cast<int>(ObjectType::COMPONENT);
+            k["uuid"] = (std::string)it.at(0);
+            j["selection"].push_back(k);
+        }
+        send_json(j);
+    });
     core_board.signal_rebuilt().connect(sigc::mem_fun(*this, &ImpBoard::update_unplaced));
     update_unplaced();
     core_board.signal_tool_changed().connect(

--- a/src/widgets/unplaced_box.hpp
+++ b/src/widgets/unplaced_box.hpp
@@ -13,9 +13,15 @@ public:
     void update(const std::map<UUIDPath<2>, std::string> &items);
     void set_title(const std::string &title);
     typedef sigc::signal<void, std::vector<UUIDPath<2>>> type_signal_place;
+    typedef sigc::signal<void, std::vector<UUIDPath<2>>> type_signal_selected;
     type_signal_place signal_place()
     {
         return s_signal_place;
+    }
+
+    type_signal_selected signal_selected()
+    {
+        return s_signal_selected;
     }
 
 private:
@@ -36,6 +42,7 @@ private:
     Gtk::ToolButton *button_place = nullptr;
 
     type_signal_place s_signal_place;
+    type_signal_selected s_signal_selected;
     void row_activated(const Gtk::TreeModel::Path &path, Gtk::TreeViewColumn *column);
 };
 } // namespace horizon


### PR DESCRIPTION
When placing components on the board it currently only highlights the component in the schematic after clicking place. This makes it highlight the component when it is selected in the unplaced components list.

It'd also be nice to have the reverse, eg make selecting in the schematic highlight the entry in the unplaced list but I didn't add it.

[Screencast_20241029_102249.webm](https://github.com/user-attachments/assets/96c6566f-3689-49e4-8a9b-8709713ba184)
