### PR TITLE
Check for mistyped/copied ".pdf" ext in datasheet url

### DIFF
--- a/src/checks/check_part.cpp
+++ b/src/checks/check_part.cpp
@@ -2,6 +2,7 @@
 #include "pool/part.hpp"
 #include "check_util.hpp"
 #include <glibmm/regex.h>
+#include <filesystem>
 
 namespace horizon {
 
@@ -53,6 +54,11 @@ RulesCheckResult check_part(const Part &part)
 
     if (needs_trim(part.get_datasheet())) {
         r.errors.emplace_back(RulesCheckErrorLevel::FAIL, "Description has trailing/leading whitespace");
+    }
+    auto ext = std::filesystem::path(part.get_datasheet()).extension().u8string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
+    if (ext == "." || (ext.find(".p") != std::string::npos && ext != ".pdf")) {
+        r.errors.emplace_back(RulesCheckErrorLevel::WARN, "Datasheet extension likely missing/mistyped");
     }
     if (auto d = check_datasheet(part.get_datasheet())) {
         r.errors.emplace_back(RulesCheckErrorLevel::WARN, "Discouraged datasheet domain " + *d);


### PR DESCRIPTION
I had copy / pasted a url and accidentally skipped the last character causing the link to not work.  

Since most datasheets are pdfs, this shows a check warning if the datasheet url ends with "." or if it has ".p" but doesn't match ".pdf". 

<img width="1318" height="509" alt="image" src="https://github.com/user-attachments/assets/905626aa-1f60-4883-b420-b04e6e4bf273" />
