### PR TITLE
Show via and junction positions in hud

### DIFF
--- a/src/imp/imp_board.cpp
+++ b/src/imp/imp_board.cpp
@@ -1156,6 +1156,12 @@ std::string ImpBoard::get_hud_text(std::set<SelectableRef> &sel)
         }
     }
     trim(s);
+    if (auto it = sel_find_exactly_one(sel, ObjectType::VIA)) {
+        const auto &via = core_board.get_board()->vias.at(it->uuid);
+        s += "\n\n<b>Via</b>\n";
+        s += coord_to_string(via.junction->position);
+        sel_erase_type(sel, ObjectType::VIA);
+    }
 
     // Display the delta if two items of these types are selected
     for (const ObjectType type : {ObjectType::BOARD_PACKAGE, ObjectType::BOARD_HOLE, ObjectType::VIA}) {

--- a/src/imp/imp_hud.cpp
+++ b/src/imp/imp_hud.cpp
@@ -131,7 +131,7 @@ std::string ImpBase::get_hud_text(std::set<SelectableRef> &sel)
 
     if (auto it = sel_find_exactly_one(sel, ObjectType::JUNCTION)) {
         const auto ju = core->get_junction(it->uuid);
-        s += "\n\n<b>Junction:</b>\n";
+        s += "\n\n<b>Junction</b>\n";
         if (preferences.hud_debug) {
             s += "Layers " + std::to_string(ju->layer.start()) + " — " + std::to_string(ju->layer.end()) + "\n";
             const Net *net = nullptr;


### PR DESCRIPTION
When a single via or junction is selected the hud it currently shows "Other: 1 Via/Junction". This makes it show the position.

<img width="1016" height="755" alt="image" src="https://github.com/user-attachments/assets/c36d7a65-4898-4607-80d5-0e1b460f3f0c" />
