### PR TITLE
Support for PoDoFo 1.x

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -153,7 +153,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
-      run: zypper in -y -t pattern devel_python3 && zypper in -y --allow-downgrade git make gcc gcc-c++ pkgconf-pkg-config cppzmq-devel occt-devel gtkmm3-devel libgit2-devel libuuid-devel sqlite3-devel librsvg-devel cairomm-devel glm-devel boost-devel libcurl-devel libpodofo-0_10-devel binutils libarchive-devel libspnav-devel meson cmake
+      run: zypper in -y -t pattern devel_python3 && zypper in -y --allow-downgrade git make gcc gcc-c++ pkgconf-pkg-config cppzmq-devel occt-devel gtkmm3-devel libgit2-devel libuuid-devel sqlite3-devel librsvg-devel cairomm-devel glm-devel boost-devel libcurl-devel libpodofo-devel binutils libarchive-devel libspnav-devel meson cmake
 
     - name: Install python dependencies
       if: ${{ matrix.target == 'horizon.so' }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -169,6 +169,34 @@ jobs:
       if: ${{ matrix.target == 'horizon.so' }}
       run: python3 -c 'import sys; sys.path.append("../build"); import horizon'
 
+  build-fedora:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - all
+          - horizon.so
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    needs: stylecheck
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: dnf install -y git make gcc gcc-c++ pkg-config cppzmq-devel opencascade-devel gtkmm30-devel libgit2-devel libuuid-devel sqlite-devel librsvg2-devel cairomm-devel glm-devel boost-devel libcurl-devel podofo-devel libarchive-devel libspnav-devel meson cmake
+    - name: Install python dependencies
+      if: ${{ matrix.target == 'horizon.so' }}
+      run: dnf install -y mesa-libGL-devel python3-cairo-devel python3-pyyaml
+    - name: Build
+      run: |
+        mkdir ../build
+        CXX=${{ matrix.os.cxx }} CC=${{ matrix.os.cc }} meson setup ../build
+        ninja -C ../build ${{ matrix.target }}
+    - name: Check version
+      run: python3 check_version.py
+    - name: Test python module
+      if: ${{ matrix.target == 'horizon.so' }}
+      run: python3 -c 'import sys; sys.path.append("../build"); import horizon'
+
   build-debug:
     runs-on: ubuntu-latest
     container: debian:bookworm

--- a/meson.build
+++ b/meson.build
@@ -843,7 +843,7 @@ color_presets_json = custom_target(
 
 if is_windows
 	windows = import('windows')
-	
+
 	horizon_eda_rc = custom_target(
         'horizon-eda.rc',
         output : 'horizon-eda.rc',
@@ -967,7 +967,7 @@ horizon_eda = executable('horizon-eda',
     link_with: [clipper_nopic, delaunator_nopic, polypartition_nopic, poly2tri_nopic, sexpr, libhorizon, libhorizonui],
     include_directories: include_directories,
     cpp_args: cpp_args,
-    gui_app: true, 
+    gui_app: true,
     install: true
 )
 
@@ -977,7 +977,7 @@ horizon_imp = executable('horizon-imp',
     link_with: [clipper_nopic, delaunator_nopic, polypartition_nopic, poly2tri_nopic, sexpr, dxflib, footag, router, libhorizon, libhorizonui],
     include_directories: include_directories,
     cpp_args: cpp_args,
-    gui_app: true, 
+    gui_app: true,
     install: true
 )
 

--- a/src/export_pdf/canvas_pdf.cpp
+++ b/src/export_pdf/canvas_pdf.cpp
@@ -66,7 +66,11 @@ void CanvasPDF::img_line(const Coordi &p0, const Coordi &p1, const uint64_t widt
         rp1 = transform.transform(p1);
     }
     auto color = get_pdf_layer_color(layer);
+#if PODOFO_VERSION_MAJOR >= 1
+    painter.GraphicsState.SetStrokingColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#else
     painter.GraphicsState.SetStrokeColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#endif
     painter.DrawLine(to_pt(rp0.x), to_pt(rp0.y), to_pt(rp1.x), to_pt(rp1.y));
 }
 
@@ -144,8 +148,13 @@ void CanvasPDF::img_draw_text(const Coordf &p, float size, const std::string &rt
         Coordi p0(xshift, yshift);
         Coordi pt = tf.transform(p0);
 
+#if PODOFO_VERSION_MAJOR >= 1
+        painter.GraphicsState.ConcatenateTransformationMatrix(
+                PoDoFo::Matrix(cos(fangle), sin(fangle), -sin(fangle), cos(fangle), to_pt(pt.x), to_pt(pt.y)));
+#else
         painter.GraphicsState.SetCurrentMatrix(PoDoFo::Matrix::FromCoefficients(cos(fangle), sin(fangle), -sin(fangle),
                                                                                 cos(fangle), to_pt(pt.x), to_pt(pt.y)));
+#endif
         painter.DrawText(line.c_str(), 0, to_pt(size) / -2);
         painter.Restore();
 
@@ -160,8 +169,13 @@ void CanvasPDF::img_polygon(const Polygon &ipoly, bool tr)
         return;
 
     auto color = get_pdf_layer_color(ipoly.layer);
+#if PODOFO_VERSION_MAJOR >= 1
+    painter.GraphicsState.SetNonStrokingColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+    painter.GraphicsState.SetStrokingColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#else
     painter.GraphicsState.SetFillColor(PoDoFo::PdfColor(color.r, color.g, color.b));
     painter.GraphicsState.SetStrokeColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#endif
     painter.GraphicsState.SetLineWidth(to_pt(settings.min_line_width));
     if (ipoly.usage == nullptr) { // regular patch
         draw_polygon(ipoly, tr);
@@ -201,8 +215,13 @@ void CanvasPDF::img_hole(const Hole &hole)
         return;
 
     auto color = get_pdf_layer_color(PDFExportSettings::HOLES_LAYER);
+#if PODOFO_VERSION_MAJOR >= 1
+    painter.GraphicsState.SetNonStrokingColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+    painter.GraphicsState.SetStrokingColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#else
     painter.GraphicsState.SetFillColor(PoDoFo::PdfColor(color.r, color.g, color.b));
     painter.GraphicsState.SetStrokeColor(PoDoFo::PdfColor(color.r, color.g, color.b));
+#endif
     painter.GraphicsState.SetLineWidth(to_pt(settings.min_line_width));
 
     auto hole2 = hole;

--- a/src/export_pdf/export_pdf.cpp
+++ b/src/export_pdf/export_pdf.cpp
@@ -88,17 +88,29 @@ public:
             auto &page = document.GetPages().GetPageAt(number);
             auto &annot = page.GetAnnotations().CreateAnnot<PoDoFo::PdfAnnotationLink>(rect);
             annot.SetBorderStyle(0, 0, 0);
+#if PODOFO_VERSION_MAJOR >= 1
+            annot.SetDestination(*first_pages.at(path));
+#else
             annot.SetDestination(first_pages.at(path));
+#endif
         }
         for (auto &[url, number, rect] : datasheet_annotations) {
             auto &page = document.GetPages().GetPageAt(number);
             auto &annot = page.GetAnnotations().CreateAnnot<PoDoFo::PdfAnnotationLink>(rect);
             annot.SetBorderStyle(0, 0, 0);
 
+#if PODOFO_VERSION_MAJOR >= 1
+            auto action = document.CreateAction(PoDoFo::PdfActionType::URI);
+            auto &uri_action = dynamic_cast<PoDoFo::PdfActionURI &>(*action);
+            uri_action.SetURI(PoDoFo::PdfString(url));
+
+            annot.SetAction(*action);
+#else
             auto action = std::make_shared<PoDoFo::PdfAction>(document, PoDoFo::PdfActionType::URI);
 
             action->SetURI(PoDoFo::PdfString(url));
             annot.SetAction(action);
+#endif
         }
 
         document.Save(filename);
@@ -138,7 +150,11 @@ private:
             painter.SetCanvas(page);
 
             painter.GraphicsState.SetLineCapStyle(PoDoFo::PdfLineCapStyle::Round);
+#if PODOFO_VERSION_MAJOR >= 1
+            painter.GraphicsState.SetNonStrokingColor(PoDoFo::PdfColor(0, 0, 0));
+#else
             painter.GraphicsState.SetFillColor(PoDoFo::PdfColor(0, 0, 0));
+#endif
             painter.TextState.SetFont(font, 10);
             painter.TextState.SetRenderingMode(PoDoFo::PdfTextRenderingMode::Invisible);
 
@@ -167,7 +183,11 @@ private:
                 }
             }
 
+#if PODOFO_VERSION_MAJOR >= 1
+            std::shared_ptr<PoDoFo::PdfDestination> dest = document.CreateDestination();
+#else
             auto dest = std::make_shared<PoDoFo::PdfDestination>(page);
+#endif
             if (first) {
                 first_pages.emplace(path, dest);
                 first = false;
@@ -215,6 +235,22 @@ private:
             painter.FinishDrawing();
 
             PoDoFo::PdfOutlineItem *sheet_node;
+#if PODOFO_VERSION_MAJOR >= 1
+            if (parent) {
+                sheet_node = &parent->CreateChild(PoDoFo::PdfString(sheet->name));
+            }
+            else {
+                sheet_node = &outlines->CreateRoot(PoDoFo::PdfString(sheet->name));
+            }
+            sheet_node->SetDestination(*dest);
+
+            for (auto sym : sheet->get_block_symbols_sorted()) {
+                auto &sym_node = sheet_node->CreateChild(PoDoFo::PdfString(sym->block_instance->refdes));
+                sym_node.SetDestination(*dest);
+                sym_node.SetTextFormat(PoDoFo::PdfOutlineFormat::Italic);
+                export_schematic(*sym->schematic, uuid_vec_append(path, sym->block_instance->uuid), prv, &sym_node);
+            }
+#else
             if (parent) {
                 sheet_node = parent->CreateChild(PoDoFo::PdfString(sheet->name), dest);
             }
@@ -228,6 +264,7 @@ private:
                 sym_node->SetTextFormat(PoDoFo::PdfOutlineFormat::Italic);
                 export_schematic(*sym->schematic, uuid_vec_append(path, sym->block_instance->uuid), prv, sym_node);
             }
+#endif
         }
     }
 };

--- a/src/export_pdf/export_pdf_board.cpp
+++ b/src/export_pdf/export_pdf_board.cpp
@@ -48,9 +48,23 @@ void export_pdf(const class Board &brd, const class PDFExportSettings &settings,
     auto &page = document.GetPages().CreatePage(PoDoFo::Rect(0, 0, to_pt(width), to_pt(height)));
     painter.SetCanvas(page);
     painter.GraphicsState.SetLineCapStyle(PoDoFo::PdfLineCapStyle::Round);
+#if PODOFO_VERSION_MAJOR >= 1
+    painter.GraphicsState.SetNonStrokingColor(PoDoFo::PdfColor(0, 0, 0));
+#else
     painter.GraphicsState.SetFillColor(PoDoFo::PdfColor(0, 0, 0));
+#endif
     painter.TextState.SetFont(font, 10);
     painter.TextState.SetRenderingMode(PoDoFo::PdfTextRenderingMode::Invisible);
+#if PODOFO_VERSION_MAJOR >= 1
+    if (settings.mirror) {
+        painter.GraphicsState.ConcatenateTransformationMatrix(
+                PoDoFo::Matrix(-1, 0, 0, 1, to_pt(bbox.second.x + border_width), to_pt(-bbox.first.y + border_width)));
+    }
+    else {
+        painter.GraphicsState.ConcatenateTransformationMatrix(
+                PoDoFo::Matrix(1, 0, 0, 1, to_pt(-bbox.first.x + border_width), to_pt(-bbox.first.y + border_width)));
+    }
+#else
     if (settings.mirror) {
         painter.GraphicsState.SetCurrentMatrix(PoDoFo::Matrix::FromCoefficients(
                 -1, 0, 0, 1, to_pt(bbox.second.x + border_width), to_pt(-bbox.first.y + border_width)));
@@ -59,6 +73,7 @@ void export_pdf(const class Board &brd, const class PDFExportSettings &settings,
         painter.GraphicsState.SetCurrentMatrix(PoDoFo::Matrix::FromCoefficients(
                 1, 0, 0, 1, to_pt(-bbox.first.x + border_width), to_pt(-bbox.first.y + border_width)));
     }
+#endif
     ca.layer_filter = true;
     ca.use_layer_colors = true;
 

--- a/src/export_pdf/export_pdf_util.cpp
+++ b/src/export_pdf/export_pdf_util.cpp
@@ -13,8 +13,13 @@ void render_picture(PoDoFo::PdfDocument &doc, PoDoFo::PdfPainter &painter, const
 
     painter.Save();
     const auto fangle = pl.get_angle_rad();
+#if PODOFO_VERSION_MAJOR >= 1
+    painter.GraphicsState.ConcatenateTransformationMatrix(PoDoFo::Matrix(
+            cos(fangle), sin(fangle), -sin(fangle), cos(fangle), to_pt((double)pl.shift.x), to_pt((double)pl.shift.y)));
+#else
     painter.GraphicsState.SetCurrentMatrix(PoDoFo::Matrix::FromCoefficients(
             cos(fangle), sin(fangle), -sin(fangle), cos(fangle), to_pt((double)pl.shift.x), to_pt((double)pl.shift.y)));
+#endif
     const int64_t w = pic.data->width * pic.px_size;
     const int64_t h = pic.data->height * pic.px_size;
     const auto p = Coordd(w, h) / -2;


### PR DESCRIPTION
I've updated API usage following <https://github.com/podofo/podofo/blob/master/API-MIGRATION.md>. Exporting a basic pdf seems to work fine and looks identical to one exported using 0.10.x. Unfortunately I am an extreme beginner to this so I have not tested more complex cases.

Fixes #815