### PR TITLE
Clear net diffpair on both nets

### DIFF
--- a/src/core/tools/tool_set_diffpair.cpp
+++ b/src/core/tools/tool_set_diffpair.cpp
@@ -70,14 +70,13 @@ ToolResponse ToolSetDiffpair::begin(const ToolArgs &args)
 
     if (tool_id == ToolID::CLEAR_DIFFPAIR) {
         auto net = nets.first;
-        if (net->diffpair_primary) {
-            net->diffpair = nullptr;
-            net->diffpair_primary = false;
+        auto other_net = net->diffpair;
+        if (other_net) {
+            other_net->diffpair = nullptr;
+            other_net->diffpair_primary = false;
         }
-        else {
-            net->diffpair->diffpair = nullptr;
-            net->diffpair->diffpair_primary = false;
-        }
+        net->diffpair = nullptr;
+        net->diffpair_primary = false;
         return ToolResponse::end();
     }
 


### PR DESCRIPTION
IDK if it's intentional or if something broke but currently the clear diff pair tool appears to remove one net from the pair and leave the other (at least visually on the schematic).

https://github.com/user-attachments/assets/8f85cf34-57f8-454b-b71a-7c1f40fcab8a