### PR TITLE
UX: Don't duplicate alternate names when creating new unit pin

### DIFF
--- a/src/pool-prj-mgr/pool-mgr/editors/unit_editor.cpp
+++ b/src/pool-prj-mgr/pool-mgr/editors/unit_editor.cpp
@@ -270,7 +270,6 @@ void UnitEditor::handle_add()
         pin->swap_group = pin_selected->swap_group;
         pin->direction = pin_selected->direction;
         pin->primary_name = inc_pin_name(pin_selected->primary_name);
-        pin->names = pin_selected->names;
     }
 
     int index = 0;


### PR DESCRIPTION
So basically, in the Unit Editor, when you put alternate names in a pin and then create a new pin, it duplicates the alternate names the pin might have. As it may seem obvious, it's very rare that pins have the same alternate names and I found myself removing them by hand very often. With this line removed, alternate pins are basically empty when creating a new pin.